### PR TITLE
check that encoder is defined before checking for encodeInto property

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -27,7 +27,7 @@ class Packr extends Unpackr {
 		let lastSharedStructuresLength = 0
 		let encodeUtf8 = target.utf8Write ? function(string, position, maxBytes) {
 			return target.utf8Write(string, position, maxBytes)
-		} : encoder.encodeInto ?
+		} : (encoder && encoder.encodeInto) ?
 			function(string, position) {
 				return encoder.encodeInto(string, target.subarray(position)).written
 			} : false


### PR DESCRIPTION
When running in environments like the `jsdom` environment provided by default with Jest, there is no `TextEncoder` global, so the `encoder` object is not defined and `encoder.encodeInto` triggers a `TypeError: Cannot read property 'encodeInto' of undefined`.