### PR TITLE
Use enum for FLOAT32 options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-export { Unpackr, Decoder, unpack, decode, addExtension } from './unpack'
-export { Packr, Encoder, pack, encode, ALWAYS, DECIMAL_FIT, DECIMAL_ROUND } from './pack'
+export { Unpackr, Decoder, unpack, decode, addExtension, FLOAT32_OPTIONS } from './unpack'
+export { Packr, Encoder, pack, encode } from './pack'
 
 export as namespace msgpackr;
 export class UnpackrStream {

--- a/pack.d.ts
+++ b/pack.d.ts
@@ -1,5 +1,5 @@
 import { Unpackr } from './unpack'
-export { addExtension, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT } from './unpack'
+export { addExtension, FLOAT32_OPTIONS } from './unpack'
 export class Packr extends Unpackr {
 	pack(value: any): Buffer
 	encode(value: any): Buffer

--- a/unpack.d.ts
+++ b/unpack.d.ts
@@ -1,5 +1,12 @@
+export enum FLOAT32_OPTIONS {
+	NEVER = 0,
+	ALWAYS = 1,
+	DECIMAL_ROUND = 3,
+	DECIMAL_FIT= 4
+}
+
 interface Options {
-	useFloat32?: 0 | typeof ALWAYS | typeof DECIMAL_ROUND | typeof DECIMAL_FIT
+	useFloat32?: FLOAT32_OPTIONS
 	useRecords?: boolean
 	structures?: {}[]
 	structuredClone?: boolean
@@ -27,6 +34,3 @@ export function unpack(messagePack: Buffer | Uint8Array): any
 export function decode(messagePack: Buffer | Uint8Array): any
 export function addExtension(extension: Extension): void
 export const C1: {}
-export const ALWAYS = 1
-export const DECIMAL_ROUND = 3
-export const DECIMAL_FIT = 4


### PR DESCRIPTION
Using an enum is a little easier for this numeric option:

```typescript
import {Packr, FLOAT32_OPTIONS} from "msgpackr";

const p = new Packr({
    useFloat32: FLOAT32_OPTIONS.ALWAYS
});
```