### PR TITLE
Add browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "type": "commonjs",
   "module": "./index.mjs",
   "main": "./index.js",
+  "browser": "./browser.mjs",
   "exports": {
     ".": {
       "node": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "type": "commonjs",
   "module": "./index.mjs",
   "main": "./index.js",
-  "browser": "./browser.mjs",
+  "browser": {
+    "./index.mjs": "./browser.mjs",
+    "./index.js": "./browser.js"
+  },
   "exports": {
     ".": {
       "node": {


### PR DESCRIPTION
Makes this package compatible with builders that don't support export maps yet, specifically esbuild. See [here](https://esbuild.github.io/api/#main-fields) and [here](https://github.com/evanw/esbuild/issues/187) for details.