### PR TITLE
fix(dist): only expose dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",
+  "main": "./dist/index.js",
   "keywords": [
     "MessagePack",
     "msgpack",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,6 @@
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",
-  "source": "./index.js",
-  "main": "dist/index.js",
-  "files": [
-    "dist"
-  ],
   "keywords": [
     "MessagePack",
     "msgpack",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",
+  "source": "./index.js",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "MessagePack",
     "msgpack",
@@ -19,6 +24,7 @@
   "scripts": {
     "benchmark": "node ./tests/benchmark.cjs",
     "build": "rollup -c",
+    "dry-run": "npm publish --dry-run",
     "prepare": "npm run build",
     "test": "mocha tests/test**.*js -u tdd --experimental-json-modules"
   },


### PR DESCRIPTION
this package is pointing to the index.js that is on the root level, we should only expose the dist files, this pr tries to fix this. Also you can run npm run dry-run to see which files are going to be exposed in npm