### PR TITLE
Fix issues with onInvalidDate

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -638,8 +638,10 @@ extensions = [{
 			targetView.setUint32(position, date.getMilliseconds() * 4000000 + ((seconds / 1000 / 0x100000000) >> 0))
 			targetView.setUint32(position + 4, seconds)
 		} else if (isNaN(seconds)) {
-			if (this.onInvalidDate)
+			if (this.onInvalidDate) {
+				allocateForWrite(0)
 				return pack(this.onInvalidDate())
+			}
 			// Intentionally invalid timestamp
 			let { target, targetView, position} = allocateForWrite(3)
 			target[position++] = 0xd4

--- a/tests/test.js
+++ b/tests/test.js
@@ -437,16 +437,19 @@ suite('msgpackr basic tests', function(){
 		var data = {
 			map: map,
 			date: new Date(1532219539011),
+			invalidDate: new Date('invalid')
 		}
 		let packr = new Packr({
 			mapsAsObjects: true,
 			useTimestamp32: true,
+			onInvalidDate: () => 'Custom invalid date'
 		})
 		var serialized = packr.pack(data)
 		var deserialized = packr.unpack(serialized)
 		assert.equal(deserialized.map[4], 'four')
 		assert.equal(deserialized.map.three, 3)
 		assert.equal(deserialized.date.getTime(), 1532219539000)
+		assert.equal(deserialized.invalidDate, 'Custom invalid date')
 	})
 	test('key caching', function() {
 		var data = {

--- a/unpack.d.ts
+++ b/unpack.d.ts
@@ -21,6 +21,7 @@ export interface Options {
 	shouldShareStructure?: (keys: string[]) => boolean
 	getStructures?(): {}[]
 	saveStructures?(structures: {}[]): boolean | void
+	onInvalidDate?: () => any
 }
 interface Extension {
 	Class: Function


### PR DESCRIPTION
Using a custom onInvalidDate previously caused an error because the codepath never called `allocateForWrite`, resulting in `target` staying `null`. I'm not sure if `allocateForWrite(0)` is a _good_ solution for this since I'm not very familiar with the codebase – it might be better to wrap the `pack` passed to extensions such that it checks if `allocateForWrite` hasn't been called and restores `target` if so.