### PR TITLE
fix image float in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 [![module](https://img.shields.io/badge/module-ESM%2FCJS-blue)](README.md)
 [![license](https://img.shields.io/badge/license-MIT-brightgreen)](LICENSE)
 
+<img align="right" src="./assets/performance.png" width="380"/>
 
-The msgpackr package is an extremely fast MessagePack NodeJS/JavaScript implementation. Currently, it is significantly faster than any other known implementations, faster than Avro (for JS), and generally faster than native V8 JSON.stringify/parse, on NodeJS. It also includes an optional record extension (the `r` in msgpackr), for defining record structures that makes MessagePack even faster and more compact, often over twice as fast as even native JSON functions, several times faster than other JS implementations, and 15-50% more compact. See the performance section for more details. Structured cloning (with support for cyclical references) is also supported through optional extensions.<img align="right" src="./assets/performance.png" width="380"/>
+The msgpackr package is an extremely fast MessagePack NodeJS/JavaScript implementation. Currently, it is significantly faster than any other known implementations, faster than Avro (for JS), and generally faster than native V8 JSON.stringify/parse, on NodeJS. It also includes an optional record extension (the `r` in msgpackr), for defining record structures that makes MessagePack even faster and more compact, often over twice as fast as even native JSON functions, several times faster than other JS implementations, and 15-50% more compact. See the performance section for more details. Structured cloning (with support for cyclical references) is also supported through optional extensions.
 
 ## Basic Usage
 


### PR DESCRIPTION
[Rendered](https://github.com/kriszyp/msgpackr/blob/638818e3f87f2a1be777ab6a88cc4bcc140c8a92/README.md)

![image](https://user-images.githubusercontent.com/4723091/150056840-c708b3ed-2a8b-4071-9ff4-077cecd1f24a.png)

vs

![image](https://user-images.githubusercontent.com/4723091/150056863-37ec5766-e1c1-4bc3-8f17-d4cb0c25aa4c.png)

If you want it below the "Basic Usage" header, place the HTML immediately after the `# Basic Usage` line.