### PR TITLE
add sparse option to drop null/undefined from objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `sequential` - Encode structures in serialized data, and reference previously encoded structures with expectation that decoder will read the encoded structures in the same order as encoded, with `unpackMultiple`.
 * `largeBigIntToFloat` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a float-64 (otherwise will throw a RangeError).
 * `encodeUndefinedAsNil` - Encodes a value of `undefined` as a MessagePack `nil`, the same as a `null`.
+* `sparse` - Drop object keys with null or undefined values. This is useful when unpacking into a fixed structure where keys with null or undefined values have assumed defaults.
 * `int64AsNumber` - This will decode uint64 and int64 numbers as standard JS numbers rather than as bigint numbers.
 * `onInvalidDate` - This can be provided as function that will be called when an invalid date is provided. The function can throw an error, or return a value that will be encoded in place of the invalid date. If not provided, an invalid date will be encoded as an invalid timestamp (which decodes with msgpackr back to an invalid date).
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -706,4 +706,55 @@ suite('msgpackr performance tests', function(){
 		}
 		//console.log('serialized', serialized.length, global.propertyComparisons)
 	})
+	test('sparse objects', function () {
+		var data = {
+			data: [
+				{ a: 1, name: 'one', type: 'odd', isOdd: true },
+				{ a: 2, name: 'two', type: 'even', isOdd: undefined },
+				{ a: 3, name: 'three', type: 'odd', isOdd: true },
+				{ a: 4, name: 'four', type: 'even', isOdd: null},
+				{ a: 5, name: 'five', type: 'odd', isOdd: true },
+				{ a: 6, name: 'six', type: 'even', isOdd: null }
+			],
+			description: 'some names',
+			types: ['odd', 'even'],
+			convertEnumToNum: [
+				{ prop: 'test' },
+				{ prop: 'test' },
+				{ prop: 'test' },
+				{ prop: 1 },
+				{ prop: 2 },
+				{ prop: [undefined, null] },
+				{ prop: null }
+			]
+		}
+		var expected = {
+			data: [
+				{ a: 1, name: 'one', type: 'odd', isOdd: true },
+				{ a: 2, name: 'two', type: 'even' },
+				{ a: 3, name: 'three', type: 'odd', isOdd: true },
+				{ a: 4, name: 'four', type: 'even', },
+				{ a: 5, name: 'five', type: 'odd', isOdd: true },
+				{ a: 6, name: 'six', type: 'even' }
+			],
+			description: 'some names',
+			types: ['odd', 'even'],
+			convertEnumToNum: [
+				{ prop: 'test' },
+				{ prop: 'test' },
+				{ prop: 'test' },
+				{ prop: 1 },
+				{ prop: 2 },
+				{ prop: [undefined, null] },
+				{}
+			]
+		}
+		let structures = []
+		let packr = new Packr({ structures })
+		var serialized = packr.pack(data)
+		serialized = packr.pack(data)
+		serialized = packr.pack(data)
+		var deserialized = packr.unpack(serialized)
+		assert.deepEqual(deserialized, data)
+	})
 })


### PR DESCRIPTION
I would like to drop keys with null/undefined values from objects. It would be preferable to not need to strip these values first and simply skip over them when packing. When unpacking into fixed data types, missing keys can be initialised with defaults. I've proposed adding a sparse option in this pr.