### PR TITLE
Fix issue with TS definition files using relative paths without `.js` ext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,9 @@ export {
 	clearSource,
 	roundFloat32,
 	isNativeAccelerationEnabled,
-} from './unpack'
-import { Options } from './unpack'
-export { Packr, Encoder, pack, encode } from './pack'
+} from './unpack.js'
+import { Options } from './unpack.js'
+export { Packr, Encoder, pack, encode } from './pack.js'
 import { Transform, Readable } from 'stream'
 
 export as namespace msgpackr;

--- a/pack.d.ts
+++ b/pack.d.ts
@@ -1,5 +1,5 @@
-import { Unpackr } from './unpack'
-export { addExtension, FLOAT32_OPTIONS } from './unpack'
+import { Unpackr } from './unpack.js'
+export { addExtension, FLOAT32_OPTIONS } from './unpack.js'
 export class Packr extends Unpackr {
 	pack(value: any): Buffer
 	encode(value: any): Buffer

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "msgpackr",
   "author": "Kris Zyp",
-  "version": "1.7.0-beta1",
+  "version": "1.7.1-beta1",
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "msgpackr",
   "author": "Kris Zyp",
-  "version": "1.7.1-beta1",
+  "version": "1.7.0-beta2",
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",


### PR DESCRIPTION
Use .js extension in relative imports to comply with ESM modules
https://www.typescriptlang.org/docs/handbook/esm-node.html