### PR TITLE
fix: optional chain unsupport under node v16

### DIFF
--- a/struct.js
+++ b/struct.js
@@ -492,7 +492,7 @@ function readStruct(src, position, srcEnd, unpackr) {
 			case 27: recordId = src[position++] + (src[position++] << 8) + (src[position++] << 16) + (src[position++] << 24); break;
 		}
 	}
-	let structure = unpackr.typedStructs?.[recordId];
+	let structure = unpackr.typedStructs && unpackr.typedStructs[recordId];
 	if (!structure) {
 		// copy src buffer because getStructures will override it
 		src = Uint8Array.prototype.slice.call(src, position, srcEnd);
@@ -784,7 +784,7 @@ function prepareStructures(structures, packr) {
 			packr._mergeStructures(existing);
 		return compatible;
 	};
-	packr.lastTypedStructuresLength = packr.typedStructs?.length;
+	packr.lastTypedStructuresLength = packr.typedStructs && packr.typedStructs.length;
 	return structures;
 }
 

--- a/unpack.js
+++ b/unpack.js
@@ -193,7 +193,7 @@ export function checkedRead(options) {
 
 		if (position == srcEnd) {
 			// finished reading this source, cleanup references
-			if (currentStructures?.restoreStructures)
+			if (currentStructures && currentStructures.restoreStructures)
 				restoreStructures()
 			currentStructures = null
 			src = null
@@ -208,7 +208,7 @@ export function checkedRead(options) {
 		// else more to read, but we are reading sequentially, so don't clear source yet
 		return result
 	} catch(error) {
-		if (currentStructures?.restoreStructures)
+		if (currentStructures && currentStructures.restoreStructures)
 			restoreStructures()
 		clearSource()
 		if (error instanceof RangeError || error.message.startsWith('Unexpected end of buffer') || position > srcEnd) {


### PR DESCRIPTION
It's a breaking change for optional chain and it's not support in node v12 & v14. Users are still using lower versions of node. This package does not declare an engines scope in package.json.

Some package like bull support from node v10, I think it keep compatible will be perfect.