### PR TITLE
Add support for Arrays crossing a VM boundary

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -388,7 +388,7 @@ export class Packr extends Unpackr {
 					let constructor = value.constructor
 					if (constructor === Object) {
 						writeObject(value, true)
-					} else if (constructor === Array) {
+					} else if (constructor === Array || Array.isArray(value)) {
 						length = value.length
 						if (length < 0x10) {
 							target[position++] = 0x90 | length

--- a/struct.js
+++ b/struct.js
@@ -776,7 +776,7 @@ function prepareStructures(structures, packr) {
 			let typed = existing.get('typed') || [];
 			if (typed.length !== lastTypedStructuresLength)
 				compatible = false;
-		} else if (existing instanceof Array) {
+		} else if (existing instanceof Array || Array.isArray(existing)) {
 			if (existing.length !== (packr.lastNamedStructuresLength || 0))
 				compatible = false;
 		}


### PR DESCRIPTION
Node's "vm" module allows the creation of sandboxes that don't share globals with the host. This includes Array, Function, etc. When using msgpackr inside a VM to `pack` messages coming from outside the VM, the constructor won't be "Array" (as defined in the VM).

To properly identify arrays, msgpackr should use Array.isArray. This function should find the same arrays as "instanceof Array", and more. We keep the "instanceof" check just in case this turns out to be wrong.

Creating a test for this is tricky as this requires running msgpackr inside the VM (eg: with bundling).

Repro code:
```
const { pack, unpack } = require('msgpackr');
console.log(unpack(pack(args)));
```

Create the bundle:
`npx esbuild --bundle script.js > bundle.js`

Run bundle.js inside a VM, and pass it a "complex" args object.
```
const vm = require('node:vm');
const fs = require('node:fs');

const context = {
  count: { arr: ['abc', 'def'] },
  console,
};

const script = new vm.Script(fs.readFileSync('bundle.js'));

vm.createContext(context);
script.runInContext(context);
```

This should print with this commit.
`{ arr: [ 'abc', 'def' ] }`

Without this change, this will print:
{ arr: { '0': 'abc', '1': 'def' } }