### PR TITLE
Add int64AsType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `sequential` - Encode structures in serialized data, and reference previously encoded structures with expectation that decoder will read the encoded structures in the same order as encoded, with `unpackMultiple`.
 * `largeBigIntToFloat` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a float-64 (otherwise will throw a RangeError).
 * `encodeUndefinedAsNil` - Encodes a value of `undefined` as a MessagePack `nil`, the same as a `null`.
-* `int64AsNumber` - This will decode uint64 and int64 numbers as standard JS numbers rather than as bigint numbers.
-* `int64AsString` - This will decode uint64 and int64 numbers as strings rather than as bigint numbers.
+* `int64AsType` - This will decode uint64 and int64 numbers as the specified type. The type can be `bigint` (default), `number`, or `string`. 
 * `onInvalidDate` - This can be provided as function that will be called when an invalid date is provided. The function can throw an error, or return a value that will be encoded in place of the invalid date. If not provided, an invalid date will be encoded as an invalid timestamp (which decodes with msgpackr back to an invalid date).
 
 ### 32-bit Float Options

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `largeBigIntToFloat` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a float-64 (otherwise will throw a RangeError).
 * `encodeUndefinedAsNil` - Encodes a value of `undefined` as a MessagePack `nil`, the same as a `null`.
 * `int64AsNumber` - This will decode uint64 and int64 numbers as standard JS numbers rather than as bigint numbers.
+* `int64AsString` - This will decode uint64 and int64 numbers as strings rather than as bigint numbers.
 * `onInvalidDate` - This can be provided as function that will be called when an invalid date is provided. The function can throw an error, or return a value that will be encoded in place of the invalid date. If not provided, an invalid date will be encoded as an invalid timestamp (which decodes with msgpackr back to an invalid date).
 
 ### 32-bit Float Options

--- a/index.d.cts
+++ b/index.d.cts
@@ -20,8 +20,9 @@ export interface Options {
 	encodeUndefinedAsNil?: boolean
 	maxSharedStructures?: number
 	maxOwnStructures?: number
+	/** @deprecated use int64AsType: 'number' */
 	int64AsNumber?: boolean
-	int64AsString?: boolean
+	int64AsType?: 'bigint' | 'number' | 'string'
 	shouldShareStructure?: (keys: string[]) => boolean
 	getStructures?(): {}[]
 	saveStructures?(structures: {}[]): boolean | void

--- a/index.d.cts
+++ b/index.d.cts
@@ -21,6 +21,7 @@ export interface Options {
 	maxSharedStructures?: number
 	maxOwnStructures?: number
 	int64AsNumber?: boolean
+	int64AsString?: boolean
 	shouldShareStructure?: (keys: string[]) => boolean
 	getStructures?(): {}[]
 	saveStructures?(structures: {}[]): boolean | void

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,8 +20,9 @@ export interface Options {
 	encodeUndefinedAsNil?: boolean
 	maxSharedStructures?: number
 	maxOwnStructures?: number
+	/** @deprecated use int64AsType: 'number' */
 	int64AsNumber?: boolean
-	int64AsString?: boolean
+	int64AsType?: 'bigint' | 'number' | 'string'
 	shouldShareStructure?: (keys: string[]) => boolean
 	getStructures?(): {}[]
 	saveStructures?(structures: {}[]): boolean | void

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ export interface Options {
 	maxSharedStructures?: number
 	maxOwnStructures?: number
 	int64AsNumber?: boolean
+	int64AsString?: boolean
 	shouldShareStructure?: (keys: string[]) => boolean
 	getStructures?(): {}[]
 	saveStructures?(structures: {}[]): boolean | void

--- a/tests/test.js
+++ b/tests/test.js
@@ -714,6 +714,17 @@ suite('msgpackr basic tests', function() {
 		var deserialized = packr.unpack(serialized)
 		assert.deepEqual(deserialized.a, 325283295382932843)
 	})
+	test('bigint to string', function() {
+		var data = {
+			a: 325283295382932843n,
+		}
+		let packr = new Packr({
+			int64AsString: true
+		})
+		var serialized = packr.pack(data)
+		var deserialized = packr.unpack(serialized)
+		assert.deepEqual(deserialized.a, '325283295382932843')
+	})
 	test('numbers', function(){
 		var data = {
 			bigEncodable: 48978578104322,

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,9 +1,8 @@
-import * as msgpackr from '../index.js'
-import '../struct.js'
-import chai from 'chai'
-import inspector  from 'inspector';
+import chai from 'chai';
+import * as msgpackr from '../index.js';
+import '../struct.js';
 //inspector.open(9229, null, true); debugger
-import { readFileSync } from 'fs'
+import { readFileSync } from 'fs';
 let allSampleData = [];
 for (let i = 1; i < 6; i++) {
 	allSampleData.push(JSON.parse(readFileSync(new URL(`./example${i > 1 ? i : ''}.json`, import.meta.url))));
@@ -703,7 +702,29 @@ suite('msgpackr basic tests', function() {
 		var deserialized = packr.unpack(serialized)
 		assert.deepEqual(deserialized, data)
 	})
+	test('int64/uint64 should be bigints by default', function() {
+		var data = {
+			a: 325283295382932843n
+		}
+
+		let packr = new Packr()
+		var serialized = packr.pack(data)
+		var deserialized = packr.unpack(serialized)
+		assert.deepEqual(deserialized.a, 325283295382932843n)
+	})
 	test('bigint to float', function() {
+		var data = {
+			a: 325283295382932843n
+		}
+		let packr = new Packr({
+			int64AsType: 'number'
+		})
+		var serialized = packr.pack(data)
+		var deserialized = packr.unpack(serialized)
+		assert.deepEqual(deserialized.a, 325283295382932843)
+	})
+	test('int64AsNumber compatibility', function() {
+		// https://github.com/kriszyp/msgpackr/pull/85
 		var data = {
 			a: 325283295382932843n
 		}
@@ -719,7 +740,7 @@ suite('msgpackr basic tests', function() {
 			a: 325283295382932843n,
 		}
 		let packr = new Packr({
-			int64AsString: true
+			int64AsType: 'string'
 		})
 		var serialized = packr.pack(data)
 		var deserialized = packr.unpack(serialized)

--- a/unpack.js
+++ b/unpack.js
@@ -359,6 +359,8 @@ export function read() {
 				if (currentUnpackr.int64AsNumber) {
 					value = dataView.getUint32(position) * 0x100000000
 					value += dataView.getUint32(position + 4)
+				} else if (currentUnpackr.int64AsString) {
+					value = dataView.getBigUint64(position).toString()
 				} else
 					value = dataView.getBigUint64(position)
 				position += 8
@@ -379,6 +381,8 @@ export function read() {
 				if (currentUnpackr.int64AsNumber) {
 					value = dataView.getInt32(position) * 0x100000000
 					value += dataView.getUint32(position + 4)
+				} else if (currentUnpackr.int64AsString) {
+					value = dataView.getBigInt64(position).toString()
 				} else
 					value = dataView.getBigInt64(position)
 				position += 8

--- a/unpack.js
+++ b/unpack.js
@@ -54,6 +54,9 @@ export class Unpackr {
 				(options.structures = []).uninitialized = true // this is what we use to denote an uninitialized structures
 				options.structures.sharedLength = 0
 			}
+			if (options.int64AsNumber) {
+				options.int64AsType = 'number'
+			}
 		}
 		Object.assign(this, options)
 	}
@@ -356,10 +359,10 @@ export function read() {
 				position += 4
 				return value
 			case 0xcf:
-				if (currentUnpackr.int64AsNumber) {
+				if (currentUnpackr.int64AsType === 'number') {
 					value = dataView.getUint32(position) * 0x100000000
 					value += dataView.getUint32(position + 4)
-				} else if (currentUnpackr.int64AsString) {
+				} else if (currentUnpackr.int64AsType === 'string') {
 					value = dataView.getBigUint64(position).toString()
 				} else
 					value = dataView.getBigUint64(position)
@@ -378,10 +381,10 @@ export function read() {
 				position += 4
 				return value
 			case 0xd3:
-				if (currentUnpackr.int64AsNumber) {
+				if (currentUnpackr.int64AsType === 'number') {
 					value = dataView.getInt32(position) * 0x100000000
 					value += dataView.getUint32(position + 4)
-				} else if (currentUnpackr.int64AsString) {
+				} else if (currentUnpackr.int64AsType === 'string') {
 					value = dataView.getBigInt64(position).toString()
 				} else
 					value = dataView.getBigInt64(position)


### PR DESCRIPTION
I need int64s/uint64s as strings instead of bigints for compatibility with other libraries, which isn't something any other messagepack library can do. 