### PR TITLE
Safely stringify bigints for error messages

### DIFF
--- a/unpack.js
+++ b/unpack.js
@@ -210,7 +210,10 @@ export function checkedRead(options) {
 			// over read
 			throw new Error('Unexpected end of MessagePack data')
 		} else if (!sequentialMode) {
-			throw new Error('Data read, but end of buffer not reached ' + JSON.stringify(result).slice(0, 100))
+			throw new Error(
+				'Data read, but end of buffer not reached ' +
+				JSON.stringify(result, (_, value) => typeof value === "bigint" ? `${value}n` : value
+			).slice(0, 100))
 		}
 		// else more to read, but we are reading sequentially, so don't clear source yet
 		return result


### PR DESCRIPTION
We went down a rabbit hole in our project as the JSON.stringify error for a BigInt hid the true error.