### PR TITLE
Additional type for int64AsType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `sequential` - Encode structures in serialized data, and reference previously encoded structures with expectation that decoder will read the encoded structures in the same order as encoded, with `unpackMultiple`.
 * `largeBigIntToFloat` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a float-64 (otherwise will throw a RangeError).
 * `encodeUndefinedAsNil` - Encodes a value of `undefined` as a MessagePack `nil`, the same as a `null`.
-* `int64AsType` - This will decode uint64 and int64 numbers as the specified type. The type can be `bigint` (default), `number`, or `string`. 
+* `int64AsType` - This will decode uint64 and int64 numbers as the specified type. The type can be `bigint` (default), `number`,  `string` or `numberOrBigInt` (where range [-2**53...2**53] is represented by number and the rest by a bigint). 
 * `onInvalidDate` - This can be provided as function that will be called when an invalid date is provided. The function can throw an error, or return a value that will be encoded in place of the invalid date. If not provided, an invalid date will be encoded as an invalid timestamp (which decodes with msgpackr back to an invalid date).
 
 ### 32-bit Float Options

--- a/tests/test.js
+++ b/tests/test.js
@@ -913,6 +913,25 @@ suite('msgpackr basic tests', function() {
 		var deserialized = packr.unpack(serialized)
 		assert.deepEqual(deserialized.a, 325283295382932843)
 	})
+	test('bigint to float or bigint', function() {
+		var data = {
+			a: -9007199254740993n,
+			b: -9007199254740992n,
+			c: 0n,
+			d: 9007199254740992n,
+			e: 9007199254740993n,
+		}
+		let packr = new Packr({
+			int64AsType: 'numberOrBigInt'
+		})
+		var serialized = packr.pack(data)
+		var deserialized = packr.unpack(serialized)
+		assert.deepEqual(deserialized.a, -9007199254740993n)
+		assert.deepEqual(deserialized.b, -9007199254740992)
+		assert.deepEqual(deserialized.c, 0)
+		assert.deepEqual(deserialized.d, 9007199254740992)
+		assert.deepEqual(deserialized.e, 9007199254740993n)
+	})
 	test('bigint to string', function() {
 		var data = {
 			a: 325283295382932843n,

--- a/unpack.js
+++ b/unpack.js
@@ -372,6 +372,9 @@ export function read() {
 					value += dataView.getUint32(position + 4)
 				} else if (currentUnpackr.int64AsType === 'string') {
 					value = dataView.getBigUint64(position).toString()
+				} else if (currentUnpackr.int64AsType === 'numberOrBigInt') {
+					value = dataView.getBigUint64(position)
+					if (value<=BigInt(2)<<BigInt(52)) value=Number(value)
 				} else
 					value = dataView.getBigUint64(position)
 				position += 8
@@ -394,6 +397,9 @@ export function read() {
 					value += dataView.getUint32(position + 4)
 				} else if (currentUnpackr.int64AsType === 'string') {
 					value = dataView.getBigInt64(position).toString()
+				} else if (currentUnpackr.int64AsType === 'numberOrBigInt') {
+					value = dataView.getBigInt64(position)
+					if (value>=BigInt(-2)<<BigInt(52)&&value<=BigInt(2)<<BigInt(52)) value=Number(value)
 				} else
 					value = dataView.getBigInt64(position)
 				position += 8


### PR DESCRIPTION
This PR adds `numberOrBigInt` value to `int64AsType` option which dynamically decodes (u)int64 based on value magnitude either as number of bigint. Values within safe (u)int range [-2**53...2**53] are returned as number and everything else as bigint,

This PR does not affect the current behaviour and must explicitly enabled to change behaviour.

The current options string `numberOrBigInt` is rather long so if a better keyword is found I would prefer it.