### PR TITLE
Refactor new `int64AsType` option value 'numberOrBigInt' to 'auto'

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `sequential` - Encode structures in serialized data, and reference previously encoded structures with expectation that decoder will read the encoded structures in the same order as encoded, with `unpackMultiple`.
 * `largeBigIntToFloat` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a float-64 (otherwise will throw a RangeError).
 * `encodeUndefinedAsNil` - Encodes a value of `undefined` as a MessagePack `nil`, the same as a `null`.
-* `int64AsType` - This will decode uint64 and int64 numbers as the specified type. The type can be `bigint` (default), `number`,  `string` or `numberOrBigInt` (where range [-2**53...2**53] is represented by number and the rest by a bigint). 
+* `int64AsType` - This will decode uint64 and int64 numbers as the specified type. The type can be `bigint` (default), `number`,  `string`, or `auto` (where range [-2^53...2^53] is represented by number and everything else by a bigint). 
 * `onInvalidDate` - This can be provided as function that will be called when an invalid date is provided. The function can throw an error, or return a value that will be encoded in place of the invalid date. If not provided, an invalid date will be encoded as an invalid timestamp (which decodes with msgpackr back to an invalid date).
 
 ### 32-bit Float Options

--- a/tests/test.js
+++ b/tests/test.js
@@ -913,7 +913,7 @@ suite('msgpackr basic tests', function() {
 		var deserialized = packr.unpack(serialized)
 		assert.deepEqual(deserialized.a, 325283295382932843)
 	})
-	test('bigint to float or bigint', function() {
+	test('bigint to auto (float or bigint)', function() {
 		var data = {
 			a: -9007199254740993n,
 			b: -9007199254740992n,
@@ -922,7 +922,7 @@ suite('msgpackr basic tests', function() {
 			e: 9007199254740993n,
 		}
 		let packr = new Packr({
-			int64AsType: 'numberOrBigInt'
+			int64AsType: 'auto'
 		})
 		var serialized = packr.pack(data)
 		var deserialized = packr.unpack(serialized)

--- a/unpack.js
+++ b/unpack.js
@@ -372,7 +372,7 @@ export function read() {
 					value += dataView.getUint32(position + 4)
 				} else if (currentUnpackr.int64AsType === 'string') {
 					value = dataView.getBigUint64(position).toString()
-				} else if (currentUnpackr.int64AsType === 'numberOrBigInt') {
+				} else if (currentUnpackr.int64AsType === 'auto') {
 					value = dataView.getBigUint64(position)
 					if (value<=BigInt(2)<<BigInt(52)) value=Number(value)
 				} else
@@ -397,7 +397,7 @@ export function read() {
 					value += dataView.getUint32(position + 4)
 				} else if (currentUnpackr.int64AsType === 'string') {
 					value = dataView.getBigInt64(position).toString()
-				} else if (currentUnpackr.int64AsType === 'numberOrBigInt') {
+				} else if (currentUnpackr.int64AsType === 'auto') {
 					value = dataView.getBigInt64(position)
 					if (value>=BigInt(-2)<<BigInt(52)&&value<=BigInt(2)<<BigInt(52)) value=Number(value)
 				} else


### PR DESCRIPTION
As discussed in #101 I've refactored the option value 'numberOrBigInt' to 'auto' which is more succinct 