### PR TITLE
move `types` condition to the front and add proper `d.cts` files for `/pack` and `/unpack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "benchmark": "node ./tests/benchmark.cjs",
-    "build": "rollup -c && cpy index.d.ts . --rename=index.d.cts",
+    "build": "rollup -c && cpy index.d.ts . --rename=index.d.cts && cpy pack.d.ts . --rename=pack.d.cts && cpy unpack.d.ts . --rename=unpack.d.cts",
     "dry-run": "npm publish --dry-run",
     "prepare": "npm run build",
     "test": "mocha tests/test**.*js -u tdd --experimental-json-modules"
@@ -28,6 +28,10 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": {
+        "require": "./index.d.cts",
+        "import": "./index.d.ts"
+      },
       "node": {
         "require": "./dist/node.cjs",
         "import": "./node-index.js"
@@ -36,13 +40,13 @@
         "require": "./dist/node.cjs",
         "import": "./node-index.js"
       },
-      "types": {
-        "require": "./index.d.cts",
-        "import": "./index.d.ts"
-      },
       "default": "./index.js"
     },
     "./pack": {
+      "types": {
+        "require": "./pack.d.cts",
+        "import": "./pack.d.ts"
+      },
       "node": {
         "import": "./index.js",
         "require": "./dist/node.cjs"
@@ -54,6 +58,10 @@
       "default": "./pack.js"
     },
     "./unpack": {
+      "types": {
+        "require": "./unpack.d.cts",
+        "import": "./unpack.d.ts"
+      },
       "node": {
         "import": "./index.js",
         "require": "./dist/node.cjs"


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

Additionally I added proper `.d.cts` files for `/pack` and `/unpack`, that should also fix "👺 Masquerading as ESM" and "⚠️ ESM (dynamic import only)", see reported errors [here](https://arethetypeswrong.github.io/?p=msgpackr%401.8.5)