### PR TITLE
Added optional offset and size parameters to unpackMultiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ unpackMultiple(data, (value) => {
 	// return false if you wish to end the parsing
 })
 ```
+If you need to know the offset and byteLength of the unpacked values, these are
+provided as optional parameters in the callback:
+```js
+let data = new Uint8Array([1, 2, 3]) // encodings of values 1, 2, and 3
+unpackMultiple(data, (value,start,size) => {
+	// called for each value
+	// start is the offset in data buffer value was read from
+	// size is the number of bytes of the encoded value
+	// return false if you wish to end the parsing
+})
+```
 
 ## Options
 The following options properties can be provided to the Packr or Unpackr constructor:

--- a/README.md
+++ b/README.md
@@ -156,14 +156,15 @@ unpackMultiple(data, (value) => {
 	// return false if you wish to end the parsing
 })
 ```
-If you need to know the offset and byteLength of the unpacked values, these are
+
+If you need to know the start and end offsets of the unpacked values, these are
 provided as optional parameters in the callback:
 ```js
 let data = new Uint8Array([1, 2, 3]) // encodings of values 1, 2, and 3
-unpackMultiple(data, (value,start,size) => {
+unpackMultiple(data, (value,start,end) => {
 	// called for each value
-	// start is the offset in data buffer value was read from
-	// size is the number of bytes of the encoded value
+	// `start` is the data buffer offset where the value was read from
+	// `end` is `start` plus the byte length of the encoded value
 	// return false if you wish to end the parsing
 })
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,12 +44,12 @@ export class Unpackr {
 	unpack(messagePack: Buffer | Uint8Array): any
 	decode(messagePack: Buffer | Uint8Array): any
 	unpackMultiple(messagePack: Buffer | Uint8Array): any[]
-	unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, size?: number) => any): void
+	unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, end?: number) => any): void
 }
 export class Decoder extends Unpackr {}
 export function unpack(messagePack: Buffer | Uint8Array): any
 export function unpackMultiple(messagePack: Buffer | Uint8Array): any[]
-export function unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, size?: number) => any): void
+export function unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, end?: number) => any): void
 export function decode(messagePack: Buffer | Uint8Array): any
 export function addExtension(extension: Extension): void
 export function clearSource(): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,12 +44,12 @@ export class Unpackr {
 	unpack(messagePack: Buffer | Uint8Array): any
 	decode(messagePack: Buffer | Uint8Array): any
 	unpackMultiple(messagePack: Buffer | Uint8Array): any[]
-	unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any) => any): void
+	unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, size?: number) => any): void
 }
 export class Decoder extends Unpackr {}
 export function unpack(messagePack: Buffer | Uint8Array): any
 export function unpackMultiple(messagePack: Buffer | Uint8Array): any[]
-export function unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any) => any): void
+export function unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, size?: number) => any): void
 export function decode(messagePack: Buffer | Uint8Array): any
 export function addExtension(extension: Extension): void
 export function clearSource(): void

--- a/tests/test.js
+++ b/tests/test.js
@@ -1062,6 +1062,14 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(values, [1, 2, 3, 4])
 	})
 
+	test('unpackMultiple with positions', () => {
+		let values = unpackMultiple(new Uint8Array([1, 2, 3, 4]))
+		assert.deepEqual(values, [1, 2, 3, 4])
+		values = []
+		unpackMultiple(new Uint8Array([1, 2, 3, 4]), (value,start,size) => values.push([value,start,size]))
+		assert.deepEqual(values, [[1,0,1], [2,1,1], [3,2,1], [4,3,1]])
+	})
+
 })
 suite('msgpackr performance tests', function(){
 	test('performance JSON.parse', function() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1066,8 +1066,8 @@ suite('msgpackr basic tests', function() {
 		let values = unpackMultiple(new Uint8Array([1, 2, 3, 4]))
 		assert.deepEqual(values, [1, 2, 3, 4])
 		values = []
-		unpackMultiple(new Uint8Array([1, 2, 3, 4]), (value,start,size) => values.push([value,start,size]))
-		assert.deepEqual(values, [[1,0,1], [2,1,1], [3,2,1], [4,3,1]])
+		unpackMultiple(new Uint8Array([1, 2, 3, 4]), (value,start,end) => values.push([value,start,end]))
+		assert.deepEqual(values, [[1,0,1], [2,1,2], [3,2,3], [4,3,4]])
 	})
 
 })

--- a/unpack.js
+++ b/unpack.js
@@ -119,10 +119,10 @@ export class Unpackr {
 			let size = source.length
 			let value = this ? this.unpack(source, size) : defaultUnpackr.unpack(source, size)
 			if (forEach) {
-				if (forEach(value) === false) return;
+				if (forEach(value,lastPosition,position - lastPosition) === false) return;
 				while(position < size) {
 					lastPosition = position
-					if (forEach(checkedRead()) === false) {
+					if (forEach(checkedRead(),lastPosition,position - lastPosition) === false) {
 						return
 					}
 				}

--- a/unpack.js
+++ b/unpack.js
@@ -119,10 +119,10 @@ export class Unpackr {
 			let size = source.length
 			let value = this ? this.unpack(source, size) : defaultUnpackr.unpack(source, size)
 			if (forEach) {
-				if (forEach(value,lastPosition,position - lastPosition) === false) return;
+				if (forEach(value,lastPosition,position) === false) return;
 				while(position < size) {
 					lastPosition = position
-					if (forEach(checkedRead(),lastPosition,position - lastPosition) === false) {
+					if (forEach(checkedRead(),lastPosition,position) === false) {
 						return
 					}
 				}


### PR DESCRIPTION
We are switching to msgpackr for packing and unpacking the streams at scrimba.com. We have streams of thousands of individual values. During decoding we need to know the actual offset of each object. Since msgpackr is so optimized (yay!) there's no simple way to retrieve that. Msgpackr reuses local variables to keep track of position.

The most natural interface I could come up with that does not impact performance in any way is to only allow peeking into these internals when you provide a callback to unpackMultiple. This PR includes the offset of each read value as the second argument, and the length (number of bytes of the encoded value) as the third argument. I ended up calling these arguments `start` and `size` in the typings (and readme), but open to changing them to something more natural. My inclination would be `offset` and `byteLength`, but since msgpackr consistently uses `position` internally I went for something else. Feel free to change names or ask me to do it.

Thanks for an incredible library! 