### PR TITLE
Include value as parameter of writeFunction

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -383,7 +383,7 @@ export class Packr extends Unpackr {
 					targetView.setFloat64(position, value)
 					position += 8
 				}
-			} else if (type === 'object') {
+			} else if (type === 'object' || type === 'function') {
 				if (!value)
 					target[position++] = 0xc0
 				else {
@@ -490,6 +490,11 @@ export class Packr extends Unpackr {
 						} else {
 							if (value.toJSON) // use this as an alternate mechanism for expressing how to serialize
 								return pack(value.toJSON());
+							
+							// if there is a writeFunction, use it, otherwise just encode as undefined
+							if (constructor === Function)
+								return pack(this.writeFunction && this.writeFunction(value));
+							
 							// no extension found, write as object
 							writeObject(value, !value.hasOwnProperty) // if it doesn't have hasOwnProperty, don't do hasOwnProperty checks
 						}
@@ -524,8 +529,6 @@ export class Packr extends Unpackr {
 					target[position++] = 0
 					target[position++] = 0
 				}
-			} else if (type === 'function') {
-				pack(this.writeFunction && this.writeFunction(value)) // if there is a writeFunction, use it, otherwise just encode as undefined
 			} else {
 				throw new Error('Unknown type: ' + type)
 			}

--- a/pack.js
+++ b/pack.js
@@ -492,7 +492,7 @@ export class Packr extends Unpackr {
 								return pack(value.toJSON());
 							
 							// if there is a writeFunction, use it, otherwise just encode as undefined
-							if (constructor === Function)
+							if (type === 'function')
 								return pack(this.writeFunction && this.writeFunction(value));
 							
 							// no extension found, write as object

--- a/pack.js
+++ b/pack.js
@@ -525,7 +525,7 @@ export class Packr extends Unpackr {
 					target[position++] = 0
 				}
 			} else if (type === 'function') {
-				pack(this.writeFunction && this.writeFunction()) // if there is a writeFunction, use it, otherwise just encode as undefined
+				pack(this.writeFunction && this.writeFunction(value)) // if there is a writeFunction, use it, otherwise just encode as undefined
 			} else {
 				throw new Error('Unknown type: ' + type)
 			}

--- a/tests/test.js
+++ b/tests/test.js
@@ -411,9 +411,6 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(data, deserialized)
 	})
 
-	
-
-
 	test('unregistered extended Array class read/write', function(){
 		var instance = new ExtendArray2()
 		instance.push(0);

--- a/tests/test.js
+++ b/tests/test.js
@@ -411,6 +411,8 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(data, deserialized)
 	})
 
+	
+
 
 	test('unregistered extended Array class read/write', function(){
 		var instance = new ExtendArray2()
@@ -562,6 +564,42 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(data, deserialized)
 		assert.strictEqual(Object.getPrototypeOf(deserialized.extendedInstance), ExtendArray3.prototype)
 		assert.equal(deserialized.extendedInstance[0], 0)
+	})
+
+	test('extended class pack/unpack proxied', function(){
+		function Extended() {
+			
+		}
+		Extended.prototype.__call__ = function(){
+			return this.value * 4
+		}
+		Extended.prototype.getDouble = function() {
+			return this.value * 2
+		}
+
+		var instance = function() { instance.__call__()/* callable stuff */ }
+		Object.setPrototypeOf(instance,Extended.prototype);
+		
+		instance.value = 4
+		var data = instance
+
+		let packr = new Packr()
+		addExtension({
+			Class: Extended,
+			type: 15,
+			unpack: function(buffer) {
+				var e = function() { e.__call__() }
+				Object.setPrototypeOf(e,Extended.prototype);
+				e.value = packr.unpack(buffer)
+				return e
+			},
+			pack: function(instance) {
+				return packr.pack(instance.value)
+			}
+		})
+		var serialized = pack(data)
+		var deserialized = unpack(serialized)
+		assert.equal(deserialized.getDouble(), 8)
 	})
 
 	test.skip('convert Date to string', function(){


### PR DESCRIPTION
We are using custom extensions to pack domain-specific objects with msgpackr. Some of the items we are trying to pack are instantiated as functions, where we change the prototype of the function to a class. I know this is _not_ a common pattern, and it would probably not make sense for msgpackr to support serializing these types of objects out of the box.

What happens is that even if our objects respond true to things like `myobject instanceof CustomFilter`, and correctly inherits all the characteristics of `CustomFilter.prototype`, the object still looks like a function to msgpackr since `typeof myobject == 'function'`. I saw in the source-code that when msgpackr tries to pack a function it calls `packr.writeFunction` if this exists. But, there is no way to get a reference to the actual value even if you do define your own `writeFunction` method.

This PR simply includes the value to be packed as the only argument to writeFunction. This way we can create our own custom writeFunction to deal with these both-a-function-and-an-object values we're dealing with, without slowing down or complicating any other parts of msgpackr.

I'm curious if writeFunction is used for anything out there in the wild. It could also be an option to allow treating `typeof 'object'` and `typeof 'function'` the same, or at least try to resolve custom extension for functions the same way.