### PR TITLE
Allow passing `useRecords` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ unpackMultiple(data, (value,start,end) => {
 ## Options
 The following options properties can be provided to the Packr or Unpackr constructor:
 
-* `useRecords` - Setting this to `false` disables the record extension and stores JavaScript objects as MessagePack maps, and unpacks maps as JavaScript `Object`s, which ensures compatibilty with other decoders.
+* `useRecords` - Setting this to `false` disables the record extension and stores JavaScript objects as MessagePack maps, and unpacks maps as JavaScript `Object`s, which ensures compatibilty with other decoders. Setting this to a function will use records for objects where `useRecords(object)` returns `true`.
 * `structures` - Provides the array of structures that is to be used for record extension, if you want the structures saved and used again. This array will be modified in place with new record structures that are serialized (if less than 32 structures are in the array).
 * `moreTypes` - Enable serialization of additional built-in types/classes including typed arrays, `Set`s, `Map`s, and `Error`s.
 * `structuredClone` - This enables the structured cloning extensions that will encode object/cyclic references. `moreTypes` is enabled by default when this is enabled.

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export enum FLOAT32_OPTIONS {
 
 export interface Options {
 	useFloat32?: FLOAT32_OPTIONS
-	useRecords?: boolean
+	useRecords?: boolean | (value:any)=> boolean
 	structures?: {}[]
 	moreTypes?: boolean
 	sequential?: boolean

--- a/tests/test.js
+++ b/tests/test.js
@@ -234,6 +234,28 @@ suite('msgpackr basic tests', function() {
 			assert.deepEqual(deserialized, data)
 		});
 
+		test('pack/unpack sample data with useRecords function ' + snippet, function () {
+			var data = [
+				{id: 1, type: 1, labels: {a: 1, b: 2}},
+				{id: 2, type: 1, labels: {b: 1, c: 2}},
+				{id: 3, type: 1, labels: {d: 1, e: 2}}
+			]
+			
+			var alternatives = [
+				{useRecords: false}, // 88 bytes
+				{useRecords: true}, // 58 bytes
+				{mapsAsObjects: true, useRecords: (v)=>!!v.id}, // 55 bytes
+				{mapsAsObjects: true, variableMapSize: true, useRecords: (v)=>!!v.id} // 49 bytes
+			]
+
+			for(let o of alternatives) {
+				let packr = new Packr(o)
+				var serialized = packr.pack(data)
+				var deserialized = packr.unpack(serialized)
+				assert.deepEqual(deserialized, data)	
+			}
+		});
+
 	}
 	test('mapAsEmptyObject combination', function () {
 		const msgpackr = new Packr({ useRecords: false, encodeUndefinedAsNil: true, variableMapSize: true, mapAsEmptyObject: true, setAsEmptyObject: true  });


### PR DESCRIPTION
See issue #112. This PR allows you to set the `useRecords` option to a function. If `useRecords` is a function, Packr will call this function for each object, and only use records when the function returns true.

When you have many structured objects combined with many smaller unstructured ones it can make packing smaller and faster, and unpacking substantially faster. For our real-world data we see around 10% size reductions and ~40% faster unpacking!

```
useRecords:(v=>!!v.id), variableMapSize: true
size: 923kb - pack 8.88069ms - unpack 6.82440ms

useRecords:(v=>!!v.id)
size: 941kb - pack 8.49143ms - unpack 5.41675ms

useRecords: true
size: 1050kb - pack 9.65734ms - unpack 10.21317ms

useRecords: false
size: 2191kb - pack 10.37920ms - unpack 16.75035ms
```

The only caveat I can think if is that you'll likely want to set `mapsAsObjects: true` if you simply replace `useRecords: true` with a function. If `useRecords` is `true`, all plain objects will be unpacked as plain objects since they are packed as records. But when you opt out of record packing for certain objects you need to remember that they will then be unpacked as maps now unless you set `mapsAsObjects` to `true`.