### PR TITLE
fix: function declaration in `index.d.ts` file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export enum FLOAT32_OPTIONS {
 
 export interface Options {
 	useFloat32?: FLOAT32_OPTIONS
-	useRecords?: boolean | (value:any)=> boolean
+	useRecords?: boolean | ((value:any)=> boolean)
 	structures?: {}[]
 	moreTypes?: boolean
 	sequential?: boolean


### PR DESCRIPTION
Previous interface was throwing `node_modules/msgpackr/index.d.ts:10:24 - error TS1385: Function type notation must be parenthesized when used in a union type.`