### PR TITLE
avoid recursion when packing with toJSON

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -488,8 +488,13 @@ export class Packr extends Unpackr {
 						if (Array.isArray(value)) {
 							packArray(value)
 						} else {
-							if (value.toJSON) // use this as an alternate mechanism for expressing how to serialize
-								return pack(value.toJSON());
+							// use this as an alternate mechanism for expressing how to serialize
+							if (value.toJSON) {
+								const json = value.toJSON()
+								// if for some reason value.toJSON returns itself it'll loop forever
+								if (json !== value)
+									return pack(json)
+							}
 							
 							// if there is a writeFunction, use it, otherwise just encode as undefined
 							if (type === 'function')

--- a/tests/test.js
+++ b/tests/test.js
@@ -1150,6 +1150,17 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(values, [[1,0,1], [2,1,2], [3,2,3], [4,3,4]])
 	})
 
+	test('pack toJSON returning this', () => {
+		class Serializable {
+			someData = [1, 2, 3, 4]
+			toJSON() {
+				return this
+			}
+		}
+		const serialized = pack(new Serializable)
+		const deserialized = unpack(serialized)
+		assert.deepStrictEqual(deserialized, { someData: [1, 2, 3, 4] })
+	})
 })
 suite('msgpackr performance tests', function(){
 	test('performance JSON.parse', function() {


### PR DESCRIPTION
For reasons outside of my control, someone might return `this` when implementing `toJSON` causing the packing logic to go into an infinite loop.

This commit implements a guard against this specific case. The logic will continue through if `value.toJSON() === value`.