### PR TITLE
Expose Packr flags + TypeScript fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,18 +42,19 @@ interface Extension {
 	read?(datum: any): any
 	write?(instance: any): any
 }
+export type UnpackOptions = { start?: number; end?: number; lazy?: boolean; } | number;
 export class Unpackr {
 	constructor(options?: Options)
-	unpack(messagePack: Buffer | Uint8Array): any
-	decode(messagePack: Buffer | Uint8Array): any
+	unpack(messagePack: Buffer | Uint8Array, options?: UnpackOptions): any
+	decode(messagePack: Buffer | Uint8Array, options?: UnpackOptions): any
 	unpackMultiple(messagePack: Buffer | Uint8Array): any[]
 	unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, end?: number) => any): void
 }
 export class Decoder extends Unpackr {}
-export function unpack(messagePack: Buffer | Uint8Array): any
+export function unpack(messagePack: Buffer | Uint8Array, options?: UnpackOptions): any
 export function unpackMultiple(messagePack: Buffer | Uint8Array): any[]
 export function unpackMultiple(messagePack: Buffer | Uint8Array, forEach: (value: any, start?: number, end?: number) => any): void
-export function decode(messagePack: Buffer | Uint8Array): any
+export function decode(messagePack: Buffer | Uint8Array, options?: UnpackOptions): any
 export function addExtension(extension: Extension): void
 export function clearSource(): void
 export function roundFloat32(float32Number: number): number
@@ -61,14 +62,14 @@ export const C1: {}
 export let isNativeAccelerationEnabled: boolean
 
 export class Packr extends Unpackr {
-	pack(value: any): Buffer
-	encode(value: any): Buffer
+	pack(value: any, encodeOptions?: number): Buffer
+	encode(value: any, encodeOptions?: number): Buffer
 	useBuffer(buffer: Buffer): void;
 	clearSharedData(): void;
 }
 export class Encoder extends Packr {}
-export function pack(value: any): Buffer
-export function encode(value: any): Buffer
+export function pack(value: any, encodeOptions?: number): Buffer
+export function encode(value: any, encodeOptions?: number): Buffer
 
 export const REUSE_BUFFER_MODE: number;
 export const RESET_BUFFER_MODE: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ interface Extension {
 	Class?: Function
 	type?: number
 	pack?(value: any): Buffer | Uint8Array
-	unpack?(messagePack: Buffer | Uint8Array): any	
+	unpack?(messagePack: Buffer | Uint8Array): any
 	read?(datum: any): any
 	write?(instance: any): any
 }
@@ -63,10 +63,16 @@ export let isNativeAccelerationEnabled: boolean
 export class Packr extends Unpackr {
 	pack(value: any): Buffer
 	encode(value: any): Buffer
+	useBuffer(buffer: Buffer): void;
+	clearSharedData(): void;
 }
 export class Encoder extends Packr {}
 export function pack(value: any): Buffer
 export function encode(value: any): Buffer
+
+export const REUSE_BUFFER_MODE: number;
+export const RESET_BUFFER_MODE: number;
+export const RESERVE_START_SPACE: number;
 
 import { Transform, Readable } from 'stream'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,7 @@ export const C1: {}
 export let isNativeAccelerationEnabled: boolean
 
 export class Packr extends Unpackr {
+	offset: number;
 	pack(value: any, encodeOptions?: number): Buffer
 	encode(value: any, encodeOptions?: number): Buffer
 	useBuffer(buffer: Buffer): void;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export { Packr, Encoder, addExtension, pack, encode, NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT, REUSE_BUFFER_MODE } from './pack.js'
+export { Packr, Encoder, addExtension, pack, encode, NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT, REUSE_BUFFER_MODE, RESET_BUFFER_MODE, RESERVE_START_SPACE } from './pack.js'
 export { Unpackr, Decoder, C1, unpack, unpackMultiple, decode, FLOAT32_OPTIONS, clearSource, roundFloat32, isNativeAccelerationEnabled } from './unpack.js'
 export { decodeIter, encodeIter } from './iterators.js'
 export const useRecords = false


### PR DESCRIPTION
Hi there,

This PR exposes the following flags:

- `REUSE_BUFFER_MODE`
- `RESET_BUFFER_MODE`
- `RESERVE_START_SPACE`

It also exposes these to TypeScript:

```typescript
export class Packr extends Unpackr {
	// ...
	offset: number;
	useBuffer(buffer: Buffer): void;
	clearSharedData(): void;
}
```

Let me know if something's missing so I can improve this PR. 

Thank you for the great work on this lib @kriszyp, cheers! 💙