### PR TITLE
allow to get/set 'position' of encoding buffer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ export let isNativeAccelerationEnabled: boolean
 
 export class Packr extends Unpackr {
 	offset: number;
+	position: number;
 	pack(value: any, encodeOptions?: number): Buffer
 	encode(value: any, encodeOptions?: number): Buffer
 	useBuffer(buffer: Buffer): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ export class Packr extends Unpackr {
 	position: number;
 	pack(value: any, encodeOptions?: number): Buffer
 	encode(value: any, encodeOptions?: number): Buffer
-	useBuffer(buffer: Buffer): void;
+	useBuffer(buffer: Buffer | Uint8Array): void;
 	clearSharedData(): void;
 }
 export class Encoder extends Packr {}

--- a/pack.js
+++ b/pack.js
@@ -53,7 +53,7 @@ export class Packr extends Unpackr {
 		if (!this.structures && options.useRecords != false)
 			this.structures = []
 		// two byte record ids for shared structures
-		let useTwoByteRecords = maxSharedStructures > 32 || (maxOwnStructures + maxSharedStructures > 64)		
+		let useTwoByteRecords = maxSharedStructures > 32 || (maxOwnStructures + maxSharedStructures > 64)
 		let sharedLimitId = maxSharedStructures + 0x40
 		let maxStructureId = maxSharedStructures + maxOwnStructures + 0x40
 		if (maxStructureId > 8256) {
@@ -71,7 +71,7 @@ export class Packr extends Unpackr {
 			}
 			safeEnd = target.length - 10
 			if (safeEnd - position < 0x800) {
-				// don't start too close to the end, 
+				// don't start too close to the end,
 				target = new ByteArrayAllocate(target.length)
 				targetView = target.dataView || (target.dataView = new DataView(target.buffer, 0, target.length))
 				safeEnd = target.length - 10
@@ -414,7 +414,7 @@ export class Packr extends Unpackr {
 							targetView.setUint32(position, referee.id)
 							position += 4
 							return
-						} else 
+						} else
 							referenceMap.set(value, { offset: position - start })
 					}
 					let constructor = value.constructor
@@ -442,7 +442,7 @@ export class Packr extends Unpackr {
 								pack(entryValue)
 							}
 						}
-					} else {	
+					} else {
 						for (let i = 0, l = extensions.length; i < l; i++) {
 							let extensionClass = extensionClasses[i]
 							if (value instanceof extensionClass) {
@@ -510,11 +510,11 @@ export class Packr extends Unpackr {
 								if (json !== value)
 									return pack(json)
 							}
-							
+
 							// if there is a writeFunction, use it, otherwise just encode as undefined
 							if (type === 'function')
 								return pack(this.writeFunction && this.writeFunction(value));
-							
+
 							// no extension found, write as plain object
 							writeObject(value)
 						}
@@ -695,7 +695,7 @@ export class Packr extends Unpackr {
 
 		// craete reference to useRecords if useRecords is a function
 		const checkUseRecords = typeof this.useRecords == 'function' && this.useRecords;
-		
+
 		const writeObject = checkUseRecords ? (object) => {
 			checkUseRecords(object) ? writeRecord(object) : writePlainObject(object)
 		} : writeRecord
@@ -825,6 +825,12 @@ export class Packr extends Unpackr {
 		target = buffer
 		targetView = new DataView(target.buffer, target.byteOffset, target.byteLength)
 		position = 0
+	}
+	set position (value) {
+		position = value;
+	}
+	get position() {
+		return position;
 	}
 	clearSharedData() {
 		if (this.structures)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "msgpackr",
+  "name": "@colyseus/msgpackr",
   "author": "Kris Zyp",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@colyseus/msgpackr",
   "author": "Kris Zyp",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",


### PR DESCRIPTION
I have a use-case where I pre-fill a `Buffer` with data, and append a msgpack-encoded message to it. As I re-use the same buffer, its "position" tend to grow indefinitely, so I need to restart its internal "position" before calling `.pack()`.

Example:

```typescript
const buffer = Buffer.allocUnsafe(1024);

// initialize (once)
const packr = new Packr();
packr.useBuffer(buffer);

// write and consume these (multiple times)
packr.position = 0; // re-set packr position
buffer[0] = 0; // ... write my own first bytes
const packedData = packr.pack({message: "hello world"}, 2048 + 1); // pack data following bytes on existing buffer

// get subarray of full initial bytes + msgpack encoded
buffer.subarray(0, packedData.byteLength);
```