### PR TITLE
Add `largeBigIntToString` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `useTimestamp32` - Encode JS `Date`s in 32-bit format when possible by dropping the milliseconds. This is a more efficient encoding of dates. You can also cause dates to use 32-bit format by manually setting the milliseconds to zero (`date.setMilliseconds(0)`).
 * `sequential` - Encode structures in serialized data, and reference previously encoded structures with expectation that decoder will read the encoded structures in the same order as encoded, with `unpackMultiple`.
 * `largeBigIntToFloat` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a float-64 (otherwise will throw a RangeError).
+* `largeBigIntToString` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded as a string (otherwise will throw a RangeError).
 * `useBigIntExtension` - If a bigint needs to be encoded that is larger than will fit in 64-bit integers, it will be encoded using a custom extension that supports up to about 1000-bits of integer precision.
 * `encodeUndefinedAsNil` - Encodes a value of `undefined` as a MessagePack `nil`, the same as a `null`.
 * `int64AsType` - This will decode uint64 and int64 numbers as the specified type. The type can be `bigint` (default), `number`,  `string`, or `auto` (where range [-2^53...2^53] is represented by number and everything else by a bigint).

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export interface Options {
 	bundleStrings?: boolean
 	useTimestamp32?: boolean
 	largeBigIntToFloat?: boolean
+	largeBigIntToString?: boolean
 	useBigIntExtension?: boolean
 	encodeUndefinedAsNil?: boolean
 	maxSharedStructures?: number

--- a/pack.js
+++ b/pack.js
@@ -536,6 +536,8 @@ export class Packr extends Unpackr {
 					if (this.largeBigIntToFloat) {
 						target[position++] = 0xcb
 						targetView.setFloat64(position, Number(value))
+					} else if (this.largeBigIntToString) {
+						return pack(value.toString());
 					} else if (this.useBigIntExtension && value < BigInt(2)**BigInt(1023) && value > -(BigInt(2)**BigInt(1023))) {
 						target[position++] = 0xc7
 						position++;
@@ -555,7 +557,8 @@ export class Packr extends Unpackr {
 						return
 					} else {
 						throw new RangeError(value + ' was too large to fit in MessagePack 64-bit integer format, use' +
-							' useBigIntExtension or set largeBigIntToFloat to convert to float-64')
+							' useBigIntExtension, or set largeBigIntToFloat to convert to float-64, or set' +
+							' largeBigIntToString to convert to string')
 					}
 				}
 				position += 8

--- a/tests/test.js
+++ b/tests/test.js
@@ -1153,6 +1153,13 @@ suite('msgpackr basic tests', function() {
 		serialized = packr.pack(tooBigInt)
 		deserialized = unpack(serialized)
 		assert.isTrue(deserialized.tooBig > 2n**65n)
+
+		packr = new Packr({
+			largeBigIntToString: true
+		})
+		serialized = packr.pack(tooBigInt)
+		deserialized = unpack(serialized)
+		assert.equal(deserialized.tooBig, (2n**66n).toString())
 	})
 
 	test('roundFloat32', function() {


### PR DESCRIPTION
There is already the `largeBigIntToFloat` config option which serializes bigints which exceed 2^64 as floats, but this loses precision.
So this PR adds the `largeBigIntToString` which serializes bigints which exceed 2^64 as strings, resulting in no lose of precision.

Obviously serializing these numeric values as strings is not as compact as it could be, but in many cases that is an ok price to pay and is more than made up for by the simplicity, eg. you can convert back to a bigint by simply using `BigInt(value)`.