### PR TITLE
fix: Google Closure Compiler internal compiler error(used by Clojurescript)

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -979,7 +979,7 @@ function writeBuffer(buffer, allocateForWrite) {
 		target[position++] = length >> 8
 		target[position++] = length & 0xff
 	} else {
-		var { target, position, targetView } = allocateForWrite(length + 5)
+		let { target, position, targetView } = allocateForWrite(length + 5)
 		target[position++] = 0xc6
 		targetView.setUint32(position, length)
 		position += 4


### PR DESCRIPTION
If use this library from Clojurescript with target :browser - following error arrives. It somehow connected to Google Closure Compiler. Fix is pretty easy - just change from 'var' to 'let' variable definition, so looks like it connected to variable scope definition. 

```
Failed to convert sources
{:tag :shadow.build.closure/convert-error, :sources [[:shadow.build.npm/resource "node_modules/msgpackr/pack.js"]]}
ExceptionInfo: failed to convert sources
        shadow.build.closure/convert-sources-simple*/fn--13161 (closure.clj:2073)
        shadow.build.closure/convert-sources-simple* (closure.clj:2060)
        shadow.build.closure/convert-sources-simple* (closure.clj:1924)
        shadow.build.closure/convert-sources-simple (closure.clj:2234)
        shadow.build.closure/convert-sources-simple (closure.clj:2184)
        shadow.build.compiler/maybe-closure-convert (compiler.clj:1385)
        shadow.build.compiler/maybe-closure-convert (compiler.clj:1378)
        shadow.build.compiler/compile-all (compiler.clj:1634)
        shadow.build.compiler/compile-all (compiler.clj:1497)
        shadow.build.api/compile-sources (api.clj:261)
        shadow.build.api/compile-sources (api.clj:253)
        shadow.build/compile (build.clj:512)
        shadow.build/compile (build.clj:493)
        shadow.cljs.devtools.server.worker.impl/build-compile (impl.clj:368)
        shadow.cljs.devtools.server.worker.impl/build-compile (impl.clj:349)
        shadow.cljs.devtools.server.worker.impl/fn--15664 (impl.clj:448)
        shadow.cljs.devtools.server.worker.impl/fn--15664 (impl.clj:437)
        clojure.lang.MultiFn.invoke (MultiFn.java:234)
        shadow.cljs.devtools.server.util/server-thread/fn--15432/fn--15433/fn--15441 (util.clj:283)
        shadow.cljs.devtools.server.util/server-thread/fn--15432/fn--15433 (util.clj:282)
        shadow.cljs.devtools.server.util/server-thread/fn--15432 (util.clj:255)
        java.lang.Thread.run (Thread.java:1583)
Caused by:
RuntimeException: INTERNAL COMPILER ERROR.
Please report this problem.

Unexpected variable targetView
  Node(NAME targetView): node_modules/msgpackr/pack.js:994:27
    var {target, position, targetView} = allocateForWrite(length + 5);
  Parent(STRING_KEY targetView): node_modules/msgpackr/pack.js:994:27
    var {target, position, targetView} = allocateForWrite(length + 5);

        com.google.javascript.jscomp.Compiler.throwInternalError (Compiler.java:3282)
        com.google.javascript.jscomp.NodeTraversal.throwUnexpectedException (NodeTraversal.java:516)
        com.google.javascript.jscomp.NodeTraversal.traverseRoots (NodeTraversal.java:560)
        com.google.javascript.jscomp.NodeTraversal$Builder.traverseRoots (NodeTraversal.java:480)
        com.google.javascript.jscomp.VarCheck.process (VarCheck.java:152)
        com.google.javascript.jscomp.PhaseOptimizer$NamedPass.process (PhaseOptimizer.java:240)
        com.google.javascript.jscomp.PhaseOptimizer.process (PhaseOptimizer.java:179)
        com.google.javascript.jscomp.Compiler.performFinalizations (Compiler.java:2980)
        com.google.javascript.jscomp.Compiler.lambda$stage3Passes$8 (Compiler.java:1048)
        com.google.javascript.jscomp.CompilerExecutor.runInCompilerThread (CompilerExecutor.java:126)
        com.google.javascript.jscomp.Compiler.runInCompilerThread (Compiler.java:1073)
        com.google.javascript.jscomp.Compiler.stage3Passes (Compiler.java:1045)
        com.google.javascript.jscomp.Compiler.compile (Compiler.java:910)
        jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
        java.lang.reflect.Method.invoke (Method.java:580)
        clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:167)
        clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:102)
        shadow.build.closure/convert-sources-simple*/fn--13161/fn--13162 (closure.clj:2063)
        shadow.build.closure/convert-sources-simple*/fn--13161 (closure.clj:2061)
        shadow.build.closure/convert-sources-simple* (closure.clj:2060)
        shadow.build.closure/convert-sources-simple* (closure.clj:1924)
        shadow.build.closure/convert-sources-simple (closure.clj:2234)
        shadow.build.closure/convert-sources-simple (closure.clj:2184)
        shadow.build.compiler/maybe-closure-convert (compiler.clj:1385)
        shadow.build.compiler/maybe-closure-convert (compiler.clj:1378)
        shadow.build.compiler/compile-all (compiler.clj:1634)
        shadow.build.compiler/compile-all (compiler.clj:1497)
        shadow.build.api/compile-sources (api.clj:261)
        shadow.build.api/compile-sources (api.clj:253)
        shadow.build/compile (build.clj:512)
        shadow.build/compile (build.clj:493)
        shadow.cljs.devtools.server.worker.impl/build-compile (impl.clj:368)
        shadow.cljs.devtools.server.worker.impl/build-compile (impl.clj:349)
        shadow.cljs.devtools.server.worker.impl/fn--15664 (impl.clj:448)
        shadow.cljs.devtools.server.worker.impl/fn--15664 (impl.clj:437)
        clojure.lang.MultiFn.invoke (MultiFn.java:234)
        shadow.cljs.devtools.server.util/server-thread/fn--15432/fn--15433/fn--15441 (util.clj:283)
        shadow.cljs.devtools.server.util/server-thread/fn--15432/fn--15433 (util.clj:282)
        shadow.cljs.devtools.server.util/server-thread/fn--15432 (util.clj:255)
        java.lang.Thread.run (Thread.java:1583)
Caused by:
IllegalStateException: Unexpected variable targetView
        com.google.javascript.jscomp.VarCheck.handleUndeclaredVariableRef (VarCheck.java:289)
        com.google.javascript.jscomp.VarCheck.checkName (VarCheck.java:211)
        com.google.javascript.jscomp.VarCheck.visit (VarCheck.java:171)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:961)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseFunction (NodeTraversal.java:1006)
        com.google.javascript.jscomp.NodeTraversal.handleFunction (NodeTraversal.java:857)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:903)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseFunction (NodeTraversal.java:1006)
        com.google.javascript.jscomp.NodeTraversal.handleFunction (NodeTraversal.java:857)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:903)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseChildren (NodeTraversal.java:1134)
        com.google.javascript.jscomp.NodeTraversal.handleScript (NodeTraversal.java:845)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:900)
        com.google.javascript.jscomp.NodeTraversal.traverseBranch (NodeTraversal.java:951)
        com.google.javascript.jscomp.NodeTraversal.traverseRoots (NodeTraversal.java:556)
        com.google.javascript.jscomp.NodeTraversal$Builder.traverseRoots (NodeTraversal.java:480)
        com.google.javascript.jscomp.VarCheck.process (VarCheck.java:152)
        com.google.javascript.jscomp.PhaseOptimizer$NamedPass.process (PhaseOptimizer.java:240)
        com.google.javascript.jscomp.PhaseOptimizer.process (PhaseOptimizer.java:179)
        com.google.javascript.jscomp.Compiler.performFinalizations (Compiler.java:2980)
        com.google.javascript.jscomp.Compiler.lambda$stage3Passes$8 (Compiler.java:1048)
        com.google.javascript.jscomp.CompilerExecutor.runInCompilerThread (CompilerExecutor.java:126)
        com.google.javascript.jscomp.Compiler.runInCompilerThread (Compiler.java:1073)
        com.google.javascript.jscomp.Compiler.stage3Passes (Compiler.java:1045)
        com.google.javascript.jscomp.Compiler.compile (Compiler.java:910)
        jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
        java.lang.reflect.Method.invoke (Method.java:580)
        clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:167)
        clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:102)
        shadow.build.closure/convert-sources-simple*/fn--13161/fn--13162 (closure.clj:2063)
        shadow.build.closure/convert-sources-simple*/fn--13161 (closure.clj:2061)
        shadow.build.closure/convert-sources-simple* (closure.clj:2060)
        shadow.build.closure/convert-sources-simple* (closure.clj:1924)
        shadow.build.closure/convert-sources-simple (closure.clj:2234)
        shadow.build.closure/convert-sources-simple (closure.clj:2184)
        shadow.build.compiler/maybe-closure-convert (compiler.clj:1385)
        shadow.build.compiler/maybe-closure-convert (compiler.clj:1378)
        shadow.build.compiler/compile-all (compiler.clj:1634)
        shadow.build.compiler/compile-all (compiler.clj:1497)
        shadow.build.api/compile-sources (api.clj:261)
        shadow.build.api/compile-sources (api.clj:253)
        shadow.build/compile (build.clj:512)
        shadow.build/compile (build.clj:493)
        shadow.cljs.devtools.server.worker.impl/build-compile (impl.clj:368)
        shadow.cljs.devtools.server.worker.impl/build-compile (impl.clj:349)
        shadow.cljs.devtools.server.worker.impl/fn--15664 (impl.clj:448)
        shadow.cljs.devtools.server.worker.impl/fn--15664 (impl.clj:437)
        clojure.lang.MultiFn.invoke (MultiFn.java:234)
        shadow.cljs.devtools.server.util/server-thread/fn--15432/fn--15433/fn--15441 (util.clj:283)
        shadow.cljs.devtools.server.util/server-thread/fn--15432/fn--15433 (util.clj:282)
        shadow.cljs.devtools.server.util/server-thread/fn--15432 (util.clj:255)
        java.lang.Thread.run (Thread.java:1583)
```
