### PR TITLE
Revert "Fix for Google Closure Compiler(used by Clojurescript)"

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -986,7 +986,7 @@ function writeBuffer(buffer, allocateForWrite) {
 		target[position++] = length >> 8
 		target[position++] = length & 0xff
 	} else {
-		let { target, position, targetView } = allocateForWrite(length + 5)
+		var { target, position, targetView } = allocateForWrite(length + 5)
 		target[position++] = 0xc6
 		targetView.setUint32(position, length)
 		position += 4


### PR DESCRIPTION
This reverts commit ce59ff0d0544ffe46f2b6a6cf7d9605754fc7bc0.

```
  1) msgpackr basic tests
       big buffer:
     TypeError: Cannot read properties of undefined (reading 'set')
      at writeBuffer (file:///D:/dev/msgpackr/pack.js:994:9)
      at Packr.pack (file:///D:/dev/msgpackr/pack.js:945:4)
      at pack (file:///D:/dev/msgpackr/pack.js:474:34)
      at Packr.pack.encode (file:///D:/dev/msgpackr/pack.js:129:6)
      at Context.<anonymous> (file:///D:/dev/msgpackr/tests/test.js:932:16)
      at process.processImmediate (node:internal/timers:511:21)
```