### PR TITLE
Support array to string conversion for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The following options properties can be provided to the Packr or Unpackr constru
 * `writeFunction` - This can be provided as function that will be called when a function is encountered. The function can throw an error, or return a value that will be encoded in place of the function. If not provided, a function will be encoded as undefined (similar to `JSON.stringify`).
 * `mapAsEmptyObject` - Encodes JS `Map`s as empty objects (for back-compat with older libraries).
 * `setAsEmptyObject` - Encodes JS `Set`s as empty objects (for back-compat with older libraries).
+* `allowArraysInMapKeys` - Allows arrays to be used as keys in Maps, as long as all elements are strings, numbers, booleans, or bigints. When enabled, such arrays are flattened and converted to a string representation.
 
 ### 32-bit Float Options
 By default all non-integer numbers are serialized as 64-bit float (double). This is fast, and ensures maximum precision. However, often real-world data doesn't not need 64-bits of precision, and using 32-bit encoding can be much more space efficient. There are several options that provide more efficient encodings. Using the decimal rounding options for encoding and decoding provides lossless storage of common decimal representations like 7.99, in more efficient 32-bit format (rather than 64-bit). The `useFloat32` property has several possible options, available from the module as constants:

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ export interface Options {
 	maxOwnStructures?: number
 	mapAsEmptyObject?: boolean
 	setAsEmptyObject?: boolean
+	allowArraysInMapKeys?: boolean
 	writeFunction?: () => any
 	/** @deprecated use int64AsType: 'number' */
 	int64AsNumber?: boolean

--- a/tests/test.js
+++ b/tests/test.js
@@ -703,7 +703,7 @@ suite('msgpackr basic tests', function() {
 			}
 	})
 
-	test('moreTyesp: Error with causes', function() {
+	test('moreTypes: Error with causes', function() {
 		const object = {
 			error: new Error('test'),
 			errorWithCause: new Error('test-1', { cause: new Error('test-2')}),
@@ -1196,6 +1196,18 @@ suite('msgpackr basic tests', function() {
 		var deserialized = unpack(serialized)
 		var deserialized = unpack(serialized)
 		assert.deepEqual(deserialized, data)
+	})
+
+	test('arrays in map keys', function() {
+		const msgpackr = new Packr({ mapsAsObjects: true, allowArraysInMapKeys: true });
+
+		const map = new Map();
+		map.set([1, 2, 3], 1);
+		map.set([1, 2, ['foo', 3.14]], 2);
+
+		const packed = msgpackr.pack(map);
+		const unpacked = msgpackr.unpack(packed);
+		assert.deepEqual(unpacked, { '1,2,3': 1, '1,2,foo,3.14': 2 });
 	})
 
 	test('utf16 causing expansion', function() {

--- a/unpack.js
+++ b/unpack.js
@@ -968,8 +968,9 @@ function readKey() {
 
 function asSafeString(property) {
 	// protect against expensive (DoS) string conversions
+	if (typeof property === 'string') return property;
+	if (typeof property === 'number' || typeof property === 'boolean' || typeof property === 'bigint') return property.toString();
 	if (property == null) return property + '';
-	if (['string', 'number', 'boolean', 'bigint'].includes(typeof property)) return property.toString();
 	if (currentUnpackr.allowArraysInMapKeys && Array.isArray(property) && property.flat().every(item => ['string', 'number', 'boolean', 'bigint'].includes(typeof item))) {
 		return property.flat().toString();
 	}

--- a/unpack.js
+++ b/unpack.js
@@ -968,10 +968,12 @@ function readKey() {
 
 function asSafeString(property) {
 	// protect against expensive (DoS) string conversions
-	if (typeof property === 'string') return property;
-	if (typeof property === 'number' || typeof property === 'boolean' || typeof property === 'bigint') return property.toString();
 	if (property == null) return property + '';
-	throw new Error('Invalid property type for record', typeof property);
+	if (['string', 'number', 'boolean', 'bigint'].includes(typeof property)) return property.toString();
+	if (Array.isArray(property) && property.flat().every(item => ['string', 'number', 'boolean', 'bigint'].includes(typeof item))) {
+		return property.flat().toString();
+	}
+	throw new Error(`Invalid property type for record: ${typeof property}`);
 }
 // the registration of the record definition extension (as "r")
 const recordDefinition = (id, highByte) => {

--- a/unpack.js
+++ b/unpack.js
@@ -970,7 +970,7 @@ function asSafeString(property) {
 	// protect against expensive (DoS) string conversions
 	if (property == null) return property + '';
 	if (['string', 'number', 'boolean', 'bigint'].includes(typeof property)) return property.toString();
-	if (Array.isArray(property) && property.flat().every(item => ['string', 'number', 'boolean', 'bigint'].includes(typeof item))) {
+	if (currentUnpackr.allowArraysInMapKeys && Array.isArray(property) && property.flat().every(item => ['string', 'number', 'boolean', 'bigint'].includes(typeof item))) {
 		return property.flat().toString();
 	}
 	throw new Error(`Invalid property type for record: ${typeof property}`);


### PR DESCRIPTION
Hello Kris 👋
This PR introduces support for using arrays of stringable primitives as Map keys. It ensures that when retrieving the map key, arrays are validated to confirm all elements are of valid types and then converted to a string representation. This enhancement addresses a use case where array-based keys are required.

Example:
```javascript
asSafeString(['john', 12, [3.14, true, Infinity]]);
// -> john,12,3.14,true,Infinity'
```