### PR TITLE
Add support for larger bigints and more error types

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -241,7 +241,7 @@ suite('msgpackr basic tests', function() {
 			{id: 2, type: 1, labels: {b: 1, c: 2}},
 			{id: 3, type: 1, labels: {d: 1, e: 2}}
 		]
-		
+
 		var alternatives = [
 			{useRecords: false}, // 88 bytes
 			{useRecords: true}, // 58 bytes
@@ -253,7 +253,7 @@ suite('msgpackr basic tests', function() {
 			let packr = new Packr(o)
 			var serialized = packr.pack(data)
 			var deserialized = packr.unpack(serialized)
-			assert.deepEqual(deserialized, data)	
+			assert.deepEqual(deserialized, data)
 		}
 	})
 
@@ -375,7 +375,7 @@ suite('msgpackr basic tests', function() {
 	})
 
 	test('BigInt', function() {
-		let packr = new Packr({useBigIntExtension: true})
+		let packr = new Packr({ useBigIntExtension: true })
 		let data = {
 			a: 3333333333333333333333333333n,
 			b: 1234567890123456789012345678901234567890n,
@@ -383,6 +383,12 @@ suite('msgpackr basic tests', function() {
 			d: -352523523642364364364264264264264264262642642n,
 			e: 0xffffffffffffffffffffffffffn,
 			f: -0xffffffffffffffffffffffffffn,
+			g: (1234n << 123n) ^ (5678n << 56n) ^ 890n,
+			h: (-1234n << 123n) ^ (5678n << 56n) ^ 890n,
+			i: (1234n << 1234n) ^ (5678n << 567n) ^ 890n,
+			j: (-1234n << 1234n) ^ (5678n << 567n) ^ 890n,
+			k: 0xdeadn << 0xbeefn,
+			l: -0xdeadn << 0xbeefn,
 		}
 		let serialized = packr.pack(data)
 		let deserialized = packr.unpack(serialized)
@@ -610,7 +616,7 @@ suite('msgpackr basic tests', function() {
 
 	test('extended class pack/unpack proxied', function(){
 		function Extended() {
-			
+
 		}
 		Extended.prototype.__call__ = function(){
 			return this.value * 4
@@ -621,7 +627,7 @@ suite('msgpackr basic tests', function() {
 
 		var instance = function() { instance.__call__()/* callable stuff */ }
 		Object.setPrototypeOf(instance,Extended.prototype);
-		
+
 		instance.value = 4
 		var data = instance
 
@@ -706,7 +712,9 @@ suite('msgpackr basic tests', function() {
 	test('moreTypes: Error with causes', function() {
 		const object = {
 			error: new Error('test'),
-			errorWithCause: new Error('test-1', { cause: new Error('test-2')}),
+			errorWithCause: new Error('test-1', { cause: new Error('test-2') }),
+			type: new TypeError(),
+			range: new RangeError('test', { cause: [1, 2] }),
 		}
 		const packr = new Packr({
 			moreTypes: true,
@@ -719,6 +727,12 @@ suite('msgpackr basic tests', function() {
 		assert.equal(deserialized.errorWithCause.message, object.errorWithCause.message)
 		assert.equal(deserialized.errorWithCause.cause.message, object.errorWithCause.cause.message)
 		assert.equal(deserialized.errorWithCause.cause.cause, object.errorWithCause.cause.cause)
+		assert.equal(deserialized.type.message, object.type.message)
+		assert.equal(deserialized.range.message, object.range.message)
+		assert.deepEqual(deserialized.range.cause, object.range.cause)
+		assert(deserialized.error instanceof Error)
+		assert(deserialized.type instanceof TypeError)
+		assert(deserialized.range instanceof RangeError)
 	})
 
 	test('structured cloning: self reference', function() {
@@ -908,7 +922,7 @@ suite('msgpackr basic tests', function() {
 			getStructures() {
 				return structures
 			},
-			saveStructures(structures) {		  
+			saveStructures(structures) {
 			},
 			maxSharedStructures: 100
 		})
@@ -916,7 +930,7 @@ suite('msgpackr basic tests', function() {
 			getStructures() {
 				return structures2
 			},
-			saveStructures(structures) {		  
+			saveStructures(structures) {
 			},
 			maxSharedStructures: 100
 		})


### PR DESCRIPTION
Hey Kris,

`msgpackr` currently has pretty decent support for the structured clone algorithm, but there's still a few gaps that I'd like to help fix. This PR implements support for encoding larger bigint values and more error types.

Bigints are currently limited to 2^1023. Removing the limit outright leads to poor decoding performance with large values due to an `O(n^2)` time complexity, and I explored a few solutions and benchmarked them:

<img src="https://github.com/user-attachments/assets/fa5209d8-731d-4796-aeb4-50978be975fe" height="400">

- The original algorithm (`O(n^2)`) decodes the bigint byte by byte, and decoding each byte require a shift with linear time complexity.
- The first optimization (`O(n^2)`) gives a >8x speedup using a `DataView` to read 8 bytes at a time.
- The second optimization (`O(n log n)`) gives a >1000x speedup with larger buffers by recursively dividing the buffer.
- I considered converting the bytes to a hex string (`O(n)`) and using the string constructor. This was still slower then the recursive algorithm for all ranges I tested, and furthermore, it seems to be a lot worse than `O(n)` on Firefox, so I decided to not go with this option.

Also, I add all the error types off of [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#error_types). Not sure why we only had three in the first place.

Lastly, I changed the `useBigIntExtension` option to be automatically active if `moreTypes` is enabled. I believe that this makes sense, since `moreTypes` already enables several other `msgpackr` extensions. `largeBigIntToFloat` and `largeBigIntToString` will still take precedence over `useBigIntExtension` as before, so this shouldn't break anything.

P.S. I also plan on implementing support for things like recursive maps/sets soon, would it be better to add those to this PR or try to keep the PRs small?
