### PR TITLE
Add support for recursive maps, sets, and DataViews

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -856,7 +856,7 @@ export class Packr extends Unpackr {
 	}
 }
 
-extensionClasses = [ Date, Set, Error, RegExp, ArrayBuffer, Object.getPrototypeOf(Uint8Array.prototype).constructor /*TypedArray*/, C1Type ]
+extensionClasses = [ Date, Set, Error, RegExp, ArrayBuffer, Object.getPrototypeOf(Uint8Array.prototype).constructor /*TypedArray*/, DataView, C1Type ]
 extensions = [{
 	pack(date, allocateForWrite, pack) {
 		let seconds = date.getTime() / 1000
@@ -942,6 +942,13 @@ extensions = [{
 			writeExtBuffer(typedArray, typedArrays.indexOf(constructor.name), allocateForWrite)
 		else
 			writeBuffer(typedArray, allocateForWrite)
+	}
+}, {
+	pack(arrayBuffer, allocateForWrite) {
+		if (this.moreTypes)
+			writeExtBuffer(arrayBuffer, 0x11, allocateForWrite)
+		else
+			writeBuffer(hasNodeBuffer ? Buffer.from(arrayBuffer) : new Uint8Array(arrayBuffer), allocateForWrite)
 	}
 }, {
 	pack(c1, allocateForWrite) { // specific 0xC1 object

--- a/pack.js
+++ b/pack.js
@@ -523,11 +523,11 @@ export class Packr extends Unpackr {
 			} else if (type === 'boolean') {
 				target[position++] = value ? 0xc3 : 0xc2
 			} else if (type === 'bigint') {
-				if (value < (BigInt(1)<<BigInt(63)) && value >= -(BigInt(1)<<BigInt(63))) {
+				if (value < 0x8000000000000000 && value >= -0x8000000000000000) {
 					// use a signed int as long as it fits
 					target[position++] = 0xd3
 					targetView.setBigInt64(position, value)
-				} else if (value < (BigInt(1)<<BigInt(64)) && value > 0) {
+				} else if (value < 0x10000000000000000 && value > 0) {
 					// if we can fit an unsigned int, use that
 					target[position++] = 0xcf
 					targetView.setBigUint64(position, value)
@@ -539,19 +539,44 @@ export class Packr extends Unpackr {
 					} else if (this.largeBigIntToString) {
 						return pack(value.toString());
 					} else if (this.useBigIntExtension || this.moreTypes) {
-						let empty = value < BigInt(0) ? BigInt(-1) : BigInt(0)
-						let mask = BigInt(0x10000000000000000) - BigInt(1) // literal would overflow
-						let chunks = []
-						do {
-							chunks.push(value & mask)
-							value >>= BigInt(64)
-						} while (value !== empty)
+						let empty = value < 0 ? BigInt(-1) : BigInt(0)
 
-						let array = new Uint8Array(new BigUint64Array(chunks).buffer)
-						array.reverse()
+						let array
+						if (value >> BigInt(0x10000) === empty) {
+							let mask = BigInt(0x10000000000000000) - BigInt(1) // literal would overflow
+							let chunks = []
+							do {
+								chunks.push(value & mask)
+								value >>= BigInt(64)
+							} while (value !== empty)
 
-						if (chunks.length + position > safeEnd)
-							makeRoom(chunks.length + position)
+							array = new Uint8Array(new BigUint64Array(chunks).buffer)
+							array.reverse()
+						} else {
+							let invert = value < 0
+							let string = (invert ? ~value : value).toString(16)
+							if (string.length % 2) {
+								string = '0' + string
+							} else if (parseInt(string.charAt(0), 16) >= 8) {
+								string = '00' + string
+							}
+
+							if (hasNodeBuffer) {
+								array = Buffer.from(string, 'hex')
+							} else {
+								array = new Uint8Array(string.length / 2)
+								for (let i = 0; i < array.length; i++) {
+									array[i] = parseInt(string.slice(i * 2, i * 2 + 2), 16)
+								}
+							}
+
+							if (invert) {
+								for (let i = 0; i < array.length; i++) array[i] = ~array[i]
+							}
+						}
+
+						if (array.length + position > safeEnd)
+							makeRoom(array.length + position)
 						position = writeExtensionData(array, target, position, 0x42)
 						return
 					} else {

--- a/tests/test.js
+++ b/tests/test.js
@@ -789,10 +789,19 @@ suite('msgpackr basic tests', function() {
 		let map = Array.from(deserialized)[0][3].map
 		assert.equal(map.get(deserialized), deserialized)
 
-		let sizeTest = new Set()
+		let sizeTestMap = new Map()
 		for (let i = 0; i < 50; i++) {
-			sizeTest.add(i || sizeTest)
-			let deserialized = packr.unpack(packr.pack(sizeTest))
+			sizeTestMap.set(i || sizeTestMap, sizeTestMap)
+			let deserialized = packr.unpack(packr.pack(sizeTestMap))
+			assert.equal(deserialized.size, i + 1)
+			assert(deserialized.has(deserialized))
+			assert(deserialized.has(i || deserialized))
+		}
+
+		let sizeTestSet = new Set()
+		for (let i = 0; i < 50; i++) {
+			sizeTestSet.add(i || sizeTestSet)
+			let deserialized = packr.unpack(packr.pack(sizeTestSet))
 			assert.equal(deserialized.size, i + 1)
 			assert(deserialized.has(deserialized))
 			assert(deserialized.has(i || deserialized))

--- a/tests/test.js
+++ b/tests/test.js
@@ -389,7 +389,15 @@ suite('msgpackr basic tests', function() {
 			j: (-1234n << 1234n) ^ (5678n << 567n) ^ 890n,
 			k: 0xdeadn << 0xbeefn,
 			l: -0xdeadn << 0xbeefn,
+			m: 11n << 0x11111n ^ 111n,
+			n: -11n << 0x11111n ^ 111n,
+			array: [],
 		}
+
+		for (let n = 7n; n.toString(16).length * 4 < 150000; n *= n) {
+			data.array.push(n, -n)
+		}
+
 		let serialized = packr.pack(data)
 		let deserialized = packr.unpack(serialized)
 		assert.deepEqual(data, deserialized)

--- a/tests/test.js
+++ b/tests/test.js
@@ -777,7 +777,9 @@ suite('msgpackr basic tests', function() {
 			set: new Set(['a', 'b']),
 			regexp: /test/gi,
 			float32Array: fa,
-			uint16Array: new Uint16Array([3,4])
+			uint16Array: new Uint16Array([3, 4]),
+			arrayBuffer: new Uint8Array([0xde, 0xad]).buffer,
+			dataView: new DataView(new Uint8Array([0xbe, 0xef]).buffer),
 		}
 		let packr = new Packr({
 			moreTypes: true,
@@ -794,6 +796,10 @@ suite('msgpackr basic tests', function() {
 		assert.equal(deserialized.uint16Array.constructor.name, 'Uint16Array')
 		assert.equal(deserialized.uint16Array[0], 3)
 		assert.equal(deserialized.uint16Array[1], 4)
+		assert.equal(deserialized.arrayBuffer.constructor.name, 'ArrayBuffer')
+		assert.equal(new DataView(deserialized.arrayBuffer).getUint16(), 0xdead)
+		assert.equal(deserialized.dataView.constructor.name, 'DataView')
+		assert.equal(deserialized.dataView.getUint16(), 0xbeef)
 	})
 	test('big bundledStrings', function() {
 		const MSGPACK_OPTIONS = {bundleStrings: true}

--- a/unpack.js
+++ b/unpack.js
@@ -1082,18 +1082,16 @@ export const typedArrays = ['Int8','Uint8','Uint8Clamped','Int16','Uint16','Int3
 let glbl = typeof globalThis === 'object' ? globalThis : window;
 currentExtensions[0x74] = (data) => {
 	let typeCode = data[0]
+	// we always have to slice to get a new ArrayBuffer that is aligned
+	let buffer = Uint8Array.prototype.slice.call(data, 1).buffer
+
 	let typedArrayName = typedArrays[typeCode]
 	if (!typedArrayName) {
-		if (typeCode === 16) {
-			let ab = new ArrayBuffer(data.length - 1)
-			let u8 = new Uint8Array(ab)
-			u8.set(data.subarray(1))
-			return ab;
-		}
+		if (typeCode === 16) return buffer
+		if (typeCode === 17) return new DataView(buffer)
 		throw new Error('Could not find typed array for code ' + typeCode)
 	}
-	// we have to always slice/copy here to get a new ArrayBuffer that is word/byte aligned
-	return new glbl[typedArrayName](Uint8Array.prototype.slice.call(data, 1).buffer)
+	return new glbl[typedArrayName](buffer)
 }
 currentExtensions[0x78] = () => {
 	let data = read()

--- a/unpack.js
+++ b/unpack.js
@@ -1132,13 +1132,13 @@ currentExtensions[0xff] = (data) => {
 		return new Date(
 			((data[0] << 22) + (data[1] << 14) + (data[2] << 6) + (data[3] >> 2)) / 1000000 +
 			((data[3] & 0x3) * 0x100000000 + data[4] * 0x1000000 + (data[5] << 16) + (data[6] << 8) + data[7]) * 1000)
-	else if (data.length == 12)// TODO: Implement support for negative
+	else if (data.length == 12)
 		return new Date(
 			((data[0] << 24) + (data[1] << 16) + (data[2] << 8) + data[3]) / 1000000 +
 			(((data[4] & 0x80) ? -0x1000000000000 : 0) + data[6] * 0x10000000000 + data[7] * 0x100000000 + data[8] * 0x1000000 + (data[9] << 16) + (data[10] << 8) + data[11]) * 1000)
 	else
 		return new Date('invalid')
-} // notepack defines extension 0 to mean undefined, so use that as the default here
+}
 // registration of bulk record definition?
 // currentExtensions[0x52] = () =>
 

--- a/unpack.js
+++ b/unpack.js
@@ -1053,7 +1053,7 @@ currentExtensions[0x69] = (data) => {
 	// TODO: handle any other types that can cycle and make the code more robust if there are other extensions
 	if (token >= 0x90 && token < 0xa0 || token == 0xdc || token == 0xdd)
 		target = []
-	else if (token == 0xde || token == 0xdf)
+	else if (token >= 0x80 && token < 0x90 || token == 0xde || token == 0xdf)
 		target = new Map()
 	else if ((token >= 0xc7 && token <= 0xc9 || token >= 0xd4 && token <= 0xd8) && src[position + 1] === 0x73)
 		target = new Set()


### PR DESCRIPTION
This is a followup to #158:
- implement encoding bigints using a hex string for very large values to avoid a quadratic time complexity
- implement recursive `Map`s and `Set`s
- implement serializing `DataView` instances