### PR TITLE
Fix useBuffer() targetView assignment

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -841,6 +841,7 @@ export class Packr extends Unpackr {
 		// this means we are finished using our own buffer and we can write over it safely
 		target = buffer
 		target.dataView || (target.dataView = new DataView(target.buffer, target.byteOffset, target.byteLength))
+		targetView = target.dataView;
 		position = 0
 	}
 	set position (value) {


### PR DESCRIPTION
The useBuffer() method was not properly initializing the module-level targetView variable, causing `TypeError: undefined is not an object (evaluating 'targetView.setFloat64')` and similar errors when packing data that requires DataView operations.

### Root Cause
When useBuffer(buffer) is called, it correctly sets:
- ✅ target = buffer
- ✅ position = 0
- ❌ targetView remains undefined
Later, when pack() executes, it checks if (!target) to decide whether to initialize. Since target is already set by useBuffer(), the initialization block that sets targetView = target.dataView is skipped, leaving targetView undefined.

### Fix
Added targetView = target.dataView to useBuffer() to ensure both target and targetView are properly initialized when using external buffers.

This enables proper buffer reuse patterns and prevents runtime errors when packing numbers, which require DataView methods like setFloat64(), setUint32(), etc.