### PR TITLE
Unreverts #158 and fix regression

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -538,22 +538,47 @@ export class Packr extends Unpackr {
 						targetView.setFloat64(position, Number(value))
 					} else if (this.largeBigIntToString) {
 						return pack(value.toString());
-					} else if ((this.useBigIntExtension || this.moreTypes) && value < BigInt(2)**BigInt(1023) && value > -(BigInt(2)**BigInt(1023))) {
-						target[position++] = 0xc7
-						position++;
-						target[position++] = 0x42 // "B" for BigInt
-						let bytes = [];
-						let alignedSign;
-						do {
-							let byte = value & BigInt(0xff);
-							alignedSign = (byte & BigInt(0x80)) === (value < BigInt(0) ? BigInt(0x80) : BigInt(0));
-							bytes.push(byte);
-							value >>= BigInt(8);
-						} while (!((value === BigInt(0) || value === BigInt(-1)) && alignedSign));
-						target[position-2] = bytes.length;
-						for (let i = bytes.length; i > 0;) {
-							target[position++] = Number(bytes[--i]);
+					} else if (this.useBigIntExtension || this.moreTypes) {
+						let empty = value < 0 ? BigInt(-1) : BigInt(0)
+
+						let array
+						if (value >> BigInt(0x10000) === empty) {
+							let mask = BigInt(0x10000000000000000) - BigInt(1) // literal would overflow
+							let chunks = []
+							while (true) {
+								chunks.push(value & mask)
+								if ((value >> BigInt(63)) === empty) break
+								value >>= BigInt(64)
+							}
+
+							array = new Uint8Array(new BigUint64Array(chunks).buffer)
+							array.reverse()
+						} else {
+							let invert = value < 0
+							let string = (invert ? ~value : value).toString(16)
+							if (string.length % 2) {
+								string = '0' + string
+							} else if (parseInt(string.charAt(0), 16) >= 8) {
+								string = '00' + string
+							}
+
+							if (hasNodeBuffer) {
+								array = Buffer.from(string, 'hex')
+							} else {
+								array = new Uint8Array(string.length / 2)
+								for (let i = 0; i < array.length; i++) {
+									array[i] = parseInt(string.slice(i * 2, i * 2 + 2), 16)
+								}
+							}
+
+							if (invert) {
+								for (let i = 0; i < array.length; i++) array[i] = ~array[i]
+							}
 						}
+
+						if (array.length + position > safeEnd)
+							makeRoom(array.length + position)
+						position = writeExtensionData(array, target, position, 0x42)
 						return
 					} else {
 						throw new RangeError(value + ' was too large to fit in MessagePack 64-bit integer format, use' +

--- a/tests/test.js
+++ b/tests/test.js
@@ -391,12 +391,18 @@ suite('msgpackr basic tests', function() {
 			l: -0xdeadn << 0xbeefn,
 			m: 11n << 0x11111n ^ 111n,
 			n: -11n << 0x11111n ^ 111n,
-			o: -12345678901234567890n,
-			array: [],
+			o: 12345678901234567890n,
+			p: -12345678901234567890n,
+			exp: [],
+			expexp: [],
+		}
+
+		for (let n = 1n; n.toString(16).length * 4 < 1500; n <<= 1n, n |= BigInt(Math.floor(Math.random() * 2))) {
+			data.exp.push(n, -n)
 		}
 
 		for (let n = 7n; n.toString(16).length * 4 < 150000; n *= n) {
-			data.array.push(n, -n)
+			data.expexp.push(n, -n)
 		}
 
 		let serialized = packr.pack(data)

--- a/tests/test.js
+++ b/tests/test.js
@@ -375,7 +375,7 @@ suite('msgpackr basic tests', function() {
 	})
 
 	test('BigInt', function() {
-		let packr = new Packr({useBigIntExtension: true})
+		let packr = new Packr({ useBigIntExtension: true })
 		let data = {
 			a: 3333333333333333333333333333n,
 			b: 1234567890123456789012345678901234567890n,
@@ -383,10 +383,22 @@ suite('msgpackr basic tests', function() {
 			d: -352523523642364364364264264264264264262642642n,
 			e: 0xffffffffffffffffffffffffffn,
 			f: -0xffffffffffffffffffffffffffn,
+			g: (1234n << 123n) ^ (5678n << 56n) ^ 890n,
+			h: (-1234n << 123n) ^ (5678n << 56n) ^ 890n,
+			i: (1234n << 1234n) ^ (5678n << 567n) ^ 890n,
+			j: (-1234n << 1234n) ^ (5678n << 567n) ^ 890n,
+			k: 0xdeadn << 0xbeefn,
+			l: -0xdeadn << 0xbeefn,
+			m: 11n << 0x11111n ^ 111n,
+			n: -11n << 0x11111n ^ 111n,
 			o: -12345678901234567890n,
 			array: [],
 		}
-		
+
+		for (let n = 7n; n.toString(16).length * 4 < 150000; n *= n) {
+			data.array.push(n, -n)
+		}
+
 		let serialized = packr.pack(data)
 		let deserialized = packr.unpack(serialized)
 		assert.deepEqual(data, deserialized)

--- a/tests/test.js
+++ b/tests/test.js
@@ -241,7 +241,7 @@ suite('msgpackr basic tests', function() {
 			{id: 2, type: 1, labels: {b: 1, c: 2}},
 			{id: 3, type: 1, labels: {d: 1, e: 2}}
 		]
-		
+
 		var alternatives = [
 			{useRecords: false}, // 88 bytes
 			{useRecords: true}, // 58 bytes
@@ -253,7 +253,7 @@ suite('msgpackr basic tests', function() {
 			let packr = new Packr(o)
 			var serialized = packr.pack(data)
 			var deserialized = packr.unpack(serialized)
-			assert.deepEqual(deserialized, data)	
+			assert.deepEqual(deserialized, data)
 		}
 	})
 
@@ -613,7 +613,7 @@ suite('msgpackr basic tests', function() {
 
 	test('extended class pack/unpack proxied', function(){
 		function Extended() {
-			
+
 		}
 		Extended.prototype.__call__ = function(){
 			return this.value * 4
@@ -624,7 +624,7 @@ suite('msgpackr basic tests', function() {
 
 		var instance = function() { instance.__call__()/* callable stuff */ }
 		Object.setPrototypeOf(instance,Extended.prototype);
-		
+
 		instance.value = 4
 		var data = instance
 
@@ -709,7 +709,9 @@ suite('msgpackr basic tests', function() {
 	test('moreTypes: Error with causes', function() {
 		const object = {
 			error: new Error('test'),
-			errorWithCause: new Error('test-1', { cause: new Error('test-2')}),
+			errorWithCause: new Error('test-1', { cause: new Error('test-2') }),
+			type: new TypeError(),
+			range: new RangeError('test', { cause: [1, 2] }),
 		}
 		const packr = new Packr({
 			moreTypes: true,
@@ -722,6 +724,12 @@ suite('msgpackr basic tests', function() {
 		assert.equal(deserialized.errorWithCause.message, object.errorWithCause.message)
 		assert.equal(deserialized.errorWithCause.cause.message, object.errorWithCause.cause.message)
 		assert.equal(deserialized.errorWithCause.cause.cause, object.errorWithCause.cause.cause)
+		assert.equal(deserialized.type.message, object.type.message)
+		assert.equal(deserialized.range.message, object.range.message)
+		assert.deepEqual(deserialized.range.cause, object.range.cause)
+		assert(deserialized.error instanceof Error)
+		assert(deserialized.type instanceof TypeError)
+		assert(deserialized.range instanceof RangeError)
 	})
 
 	test('structured cloning: self reference', function() {
@@ -950,7 +958,7 @@ suite('msgpackr basic tests', function() {
 			getStructures() {
 				return structures
 			},
-			saveStructures(structures) {		  
+			saveStructures(structures) {
 			},
 			maxSharedStructures: 100
 		})
@@ -958,7 +966,7 @@ suite('msgpackr basic tests', function() {
 			getStructures() {
 				return structures2
 			},
-			saveStructures(structures) {		  
+			saveStructures(structures) {
 			},
 			maxSharedStructures: 100
 		})

--- a/unpack.js
+++ b/unpack.js
@@ -999,15 +999,34 @@ const recordDefinition = (id, highByte) => {
 currentExtensions[0] = () => {} // notepack defines extension 0 to mean undefined, so use that as the default here
 currentExtensions[0].noBuffer = true
 
-currentExtensions[0x42] = (data) => {
-	// decode bigint
-	let length = data.length;
-	let value = BigInt(data[0] & 0x80 ? data[0] - 0x100 : data[0]);
-	for (let i = 1; i < length; i++) {
-		value <<= BigInt(8);
-		value += BigInt(data[i]);
+currentExtensions[0x42] = data => {
+	let headLength = (data.byteLength % 8) || 8
+	let head = BigInt(data[0] & 0x80 ? data[0] - 0x100 : data[0])
+	for (let i = 1; i < headLength; i++) {
+		head <<= BigInt(8)
+		head += BigInt(data[i])
 	}
-	return value;
+	if (data.byteLength !== headLength) {
+		let view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+		let decode = (start, end) => {
+			let length = end - start
+			if (length <= 40) {
+				let out = view.getBigUint64(start)
+				for (let i = start + 8; i < end; i += 8) {
+					out <<= BigInt(64n)
+					out |= view.getBigUint64(i)
+				}
+				return out
+			}
+			// if (length === 8) return view.getBigUint64(start)
+			let middle = start + (length >> 4 << 3)
+			let left = decode(start, middle)
+			let right = decode(middle, end)
+			return (left << BigInt((end - middle) * 8)) | right
+		}
+		head = (head << BigInt((view.byteLength - headLength) * 8)) | decode(headLength, view.byteLength)
+	}
+	return head
 }
 
 let errors = {

--- a/unpack.js
+++ b/unpack.js
@@ -1010,10 +1010,17 @@ currentExtensions[0x42] = (data) => {
 	return value;
 }
 
-let errors = { Error, TypeError, ReferenceError };
+let errors = {
+	Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError, AggregateError: typeof AggregateError === 'function' ? AggregateError : null,
+}
 currentExtensions[0x65] = () => {
 	let data = read()
-	return (errors[data[0]] || Error)(data[1], { cause: data[2] })
+	if (!errors[data[0]]) {
+		let error = Error(data[1], { cause: data[2] })
+		error.name = data[0]
+		return error
+	}
+	return errors[data[0]](data[1], { cause: data[2] })
 }
 
 currentExtensions[0x69] = (data) => {


### PR DESCRIPTION
This commit unreverts #158, fixes the regression in 715de16, and adds additional tests.

The fix is equivalent to this:
```diff
	while (true) {
		chunks.push(value & mask)
-		if ((value >> BigInt(64)) === empty) break
+		if ((value >> BigInt(63)) === empty) break
		value >>= BigInt(64)
	}
```
The original code incorrectly handle numbers with a bit length that's exactly a multiple of 64. The new tests test a number for each possible bit length.