### PR TITLE
Export missing pack constants

### DIFF
--- a/node-index.js
+++ b/node-index.js
@@ -1,4 +1,4 @@
-export { Packr, Encoder, addExtension, pack, encode, NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT } from './pack.js'
+export { Packr, Encoder, addExtension, pack, encode, NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT, REUSE_BUFFER_MODE, RESET_BUFFER_MODE } from './pack.js'
 export { Unpackr, Decoder, C1, unpack, unpackMultiple, decode, FLOAT32_OPTIONS, clearSource, roundFloat32, isNativeAccelerationEnabled } from './unpack.js'
 import './struct.js'
 export { PackrStream, UnpackrStream, PackrStream as EncoderStream, UnpackrStream as DecoderStream } from './stream.js'


### PR DESCRIPTION
The default Node.js and Bun entrypoint, `node-index..js`, does not export `REUSE_BUFFER_MODE`, `RESET_BUFFER_MODE`, or `RESERVE_START_SPACE` despite the type definition saying it does.