### PR TITLE
fix(types): pass required generic type into Iterable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,8 @@ export function decode(messagePack: Buffer | Uint8Array, options?: UnpackOptions
 export function addExtension(extension: Extension): void
 export function clearSource(): void
 export function roundFloat32(float32Number: number): number
-export function decodeIter(bufferIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): AsyncGenerator<any>
-export function encodeIter(objectIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): IterableIterator<Buffer> | Promise<AsyncIterableIterator<Buffer>>
+export function decodeIter(bufferIterator: Iterable<Buffer | Uint8Array> | Iterator<Buffer | Uint8Array> | AsyncIterable<Buffer | Uint8Array> | AsyncIterator<Buffer | Uint8Array>, options?: Options): AsyncGenerator<any>
+export function encodeIter(objectIterator: Iterable<Buffer | Uint8Array> | Iterator<Buffer | Uint8Array> | AsyncIterable<Buffer | Uint8Array> | AsyncIterator<Buffer | Uint8Array>, options?: Options): IterableIterator<Buffer> | Promise<AsyncIterableIterator<Buffer>>
 export const C1: {}
 export let isNativeAccelerationEnabled: boolean
 


### PR DESCRIPTION
There are TypeErrors about not passing required generic types as the following:
```bash
node_modules/msgpackr/index.d.cts:63:44 - error TS2707: Generic type 'Iterable<T, TReturn, TNext>' requires between 1 and 3 type arguments.

63 export function decodeIter(bufferIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): AsyncGenerator<any>
                                              ~~~~~~~~

node_modules/msgpackr/index.d.cts:63:55 - error TS2707: Generic type 'Iterator<T, TReturn, TNext>' requires between 1 and 3 type arguments.

63 export function decodeIter(bufferIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): AsyncGenerator<any>
                                                         ~~~~~~~~

node_modules/msgpackr/index.d.cts:63:66 - error TS2707: Generic type 'AsyncIterable<T, TReturn, TNext>' requires between 1 and 3 type arguments.

63 export function decodeIter(bufferIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): AsyncGenerator<any>
                                                                    ~~~~~~~~~~~~~

node_modules/msgpackr/index.d.cts:63:82 - error TS2707: Generic type 'AsyncIterator<T, TReturn, TNext>' requires between 1 and 3 type arguments.

63 export function decodeIter(bufferIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): AsyncGenerator<any>
                                                                                    ~~~~~~~~~~~~~

node_modules/msgpackr/index.d.cts:64:44 - error TS2707: Generic type 'Iterable<T, TReturn, TNext>' requires between 1 and 3 type arguments.

64 export function encodeIter(objectIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): IterableIterator<Buffer> | Promise<AsyncIterableIterator<Buffer>>
                                              ~~~~~~~~

node_modules/msgpackr/index.d.cts:64:55 - error TS2707: Generic type 'Iterator<T, TReturn, TNext>' requires between 1 and 3 type arguments.

64 export function encodeIter(objectIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): IterableIterator<Buffer> | Promise<AsyncIterableIterator<Buffer>>
                                                         ~~~~~~~~

node_modules/msgpackr/index.d.cts:64:66 - error TS2707: Generic type 'AsyncIterable<T, TReturn, TNext>' requires between 1 and 3 type arguments.

64 export function encodeIter(objectIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): IterableIterator<Buffer> | Promise<AsyncIterableIterator<Buffer>>
                                                                    ~~~~~~~~~~~~~

node_modules/msgpackr/index.d.cts:64:82 - error TS2707: Generic type 'AsyncIterator<T, TReturn, TNext>' requires between 1 and 3 type arguments.

64 export function encodeIter(objectIterator: Iterable | Iterator | AsyncIterable | AsyncIterator, options?: Options): IterableIterator<Buffer> | Promise<AsyncIterableIterator<Buffer>>
                                                                                    ~~~~~~~~~~~~~
```