### PR TITLE
Security: Unbounded buffering of incomplete frames can enable memory DoS

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -25,19 +25,32 @@ export class UnpackrStream extends Transform {
 		options.objectMode = true
 		super(options)
 		options.structures = []
+		this.maxIncompleteBufferSize = options.maxIncompleteBufferSize > -1 ? options.maxIncompleteBufferSize : 0x4000000
 		this.unpackr = options.unpackr || new Unpackr(options)
 	}
 	_transform(chunk, encoding, callback) {
 		if (this.incompleteBuffer) {
+			let chunkSize = this.incompleteBuffer.length + chunk.length
+			if (chunkSize > this.maxIncompleteBufferSize) {
+				this.incompleteBuffer = null
+				let error = new Error('Maximum incomplete buffer size exceeded')
+				if (callback) return callback(error)
+				throw error
+			}
 			chunk = Buffer.concat([this.incompleteBuffer, chunk])
 			this.incompleteBuffer = null
 		}
-		let values
+		let values, streamError
 		try {
 			values = this.unpackr.unpackMultiple(chunk)
 		} catch(error) {
 			if (error.incomplete) {
-				this.incompleteBuffer = chunk.slice(error.lastPosition)
+				let incompleteBuffer = chunk.slice(error.lastPosition)
+				if (incompleteBuffer.length > this.maxIncompleteBufferSize) {
+					this.incompleteBuffer = null
+					streamError = new Error('Maximum incomplete buffer size exceeded')
+				} else
+					this.incompleteBuffer = incompleteBuffer
 				values = error.values
 			}
 			else
@@ -48,6 +61,10 @@ export class UnpackrStream extends Transform {
 					value = this.getNullValue()
 				this.push(value)
 			}
+		}
+		if (streamError) {
+			if (callback) return callback(streamError)
+			throw streamError
 		}
 		if (callback) callback()
 	}


### PR DESCRIPTION
## Summary

Security: Unbounded buffering of incomplete frames can enable memory DoS

## Problem

**Severity**: `Medium` | **File**: `stream.js:L28`

`UnpackrStream` concatenates `this.incompleteBuffer` with each new chunk until a full message is parsed. A malicious sender can stream intentionally incomplete/fragmented data so `incompleteBuffer` grows without limit, causing excessive memory usage and potential process exhaustion.

## Solution

Enforce a maximum allowed buffered size for incomplete data and reject/reset when exceeded. Consider configurable limits (e.g., `maxIncompleteBufferSize`) and emit a stream error instead of continuing to accumulate.

## Changes

- `stream.js` (modified)