### PR TITLE
Rebuild structures from durable store when a save is declined

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -189,7 +189,14 @@ export class Packr extends Unpackr {
 						let newSharedData = prepareStructures(structures, packr);
 						if (!encodingError) { // TODO: If there is an encoding error, should make the structures as uninitialized so they get rebuilt next time
 							if (packr.saveStructures(newSharedData, newSharedData.isCompatible) === false) {
-								// get updated structures and try again if the update failed
+								// The save was declined (a concurrent writer updated the shared structures,
+								// or the store transaction did not durably commit). Our in-memory
+								// structures + transition trie may now reference record ids that were
+								// never persisted; re-packing as-is would re-emit the same record pointing
+								// at an unpersisted structure (-> "Record id is not defined" on decode).
+								// Mark structures uninitialized so the re-pack reloads durable structures
+								// via getStructures, rebuilds the transition trie, and re-mints + re-saves.
+								structures.uninitialized = true
 								return packr.pack(value, encodeOptions)
 							}
 							packr.lastNamedStructuresLength = sharedLength

--- a/tests/test.js
+++ b/tests/test.js
@@ -1003,6 +1003,31 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(inputData, outputData)
 	})
 
+	test('declined structure save re-packs against durable structures (no dangling record)', function() {
+		// Regression: when saveStructures declines a save (a concurrent writer updated the shared
+		// structures, or the store txn did not durably commit), the in-memory structures/transition
+		// trie reference a record id that was never persisted. The re-pack must reload the durable
+		// structures and re-mint/re-save — otherwise it re-emits the same record pointing at an
+		// unsaved structure, and reads throw "Record id is not defined".
+		const meta = new Packr()
+		let store = null
+		let declinedOnce = false
+		const packr = new Packr({
+			useRecords: true,
+			getStructures() { return store ? meta.unpack(store) : undefined },
+			saveStructures(structures) {
+				if (!declinedOnce) { declinedOnce = true; return false } // decline the first save
+				store = meta.pack(structures); return true
+			},
+		})
+		const a = packr.pack({ x: 9, y: 8 })  // first mint is declined -> must re-pack + re-save
+		const b = packr.pack({ x: 7, y: 6 })  // same shape -> must still reference a saved structure
+		// A fresh reader sees only the durably-saved structures (another thread / post-restart):
+		const reader = new Packr({ getStructures() { return store ? meta.unpack(store) : undefined } })
+		assert.deepEqual(reader.unpack(a), { x: 9, y: 8 })
+		assert.deepEqual(reader.unpack(b), { x: 7, y: 6 })
+	})
+
 	test('big buffer', function() {
 		var size = 100000000
 		var data = new Uint8Array(size).fill(1)


### PR DESCRIPTION
## Summary

When `saveStructures` returns `false` (a concurrent writer updated the shared structures, or the host store transaction did not durably commit), mark the in-memory structures **uninitialized** before re-packing so the re-pack reloads the durable structures via `getStructures`, rebuilds the transition trie, and re-mints + re-saves.

## Why

The encoder mints a shared-structure record id and encodes the record **synchronously, before** the host's `saveStructures` runs. The existing re-pack on a declined save (`return packr.pack(value)`) reused the **cached transition trie**, so it re-emitted the *same* record pointing at a structure id that was never persisted. A fresh reader (another worker thread, or after restart) then throws **`Record id is not defined for N`** — the production decode error on CDI's rt-dev cluster.

`resetStructures` only nulls `transitions` past a 10k-transition threshold, so the poisoned trie normally survives the re-pack. This extends the long-standing TODO on the adjacent `encodingError` branch ("make the structures uninitialized so they get rebuilt next time") to the **save-failure** path.

## What to look at

- One line in `pack.js` (the `saveStructures(...) === false` branch): `structures.uninitialized = true` before the re-pack. On the re-pack, the existing `if (structures.uninitialized)` reload (line ~91) pulls durable structures via `getStructures`, and `if (!structures.transitions)` rebuilds the trie.
- **Pairing:** this is half of the fix. The host's `saveStructures` must also return `false` (not `undefined`) on a non-committed save — see the companion harper change. Verified end-to-end: declined save → re-pack reloads + re-mints + re-saves → no dangling record (regression test added: "declined structure save re-packs against durable structures").
- **Re-pack termination:** the re-pack recurses on persistent `false`. In practice declines converge (CAS conflict → merge winner's structures → next save compatible; aborts are transient). A persistent-decline guard could be added but matches the pre-existing re-pack behavior.

## Tests

102 passing (added the declined-save regression). Targets the new `v1.11.x` maintenance branch for a 1.11.14 patch (deployed 5.0.x line). Will port to `master` (v2 / 5.1) as well.

🤖 Generated by Claude (Opus 4.7).