### PR TITLE
Rebuild structures from durable store when a save is declined (v2)

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -188,7 +188,14 @@ export class Packr extends Unpackr {
 						let newSharedData = (packr._prepareStructures || prepareStructures)(structures, packr);
 						if (!encodingError) { // TODO: If there is an encoding error, should make the structures as uninitialized so they get rebuilt next time
 							if (packr.saveStructures(newSharedData, newSharedData.isCompatible) === false) {
-								// get updated structures and try again if the update failed
+								// The save was declined (a concurrent writer updated the shared structures,
+								// or the store transaction did not durably commit). Our in-memory
+								// structures + transition trie may now reference record ids that were
+								// never persisted; re-packing as-is would re-emit the same record pointing
+								// at an unpersisted structure (-> "Record id is not defined" on decode).
+								// Mark structures uninitialized so the re-pack reloads durable structures
+								// via getStructures, rebuilds the transition trie, and re-mints + re-saves.
+								structures.uninitialized = true;
 								return packr.pack(value, encodeOptions);
 							}
 							packr.lastNamedStructuresLength = sharedLength;

--- a/tests/test.js
+++ b/tests/test.js
@@ -950,6 +950,30 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(inputData, outputData);
 	});
 
+	test('declined structure save re-packs against durable structures (no dangling record)', function() {
+		// Regression: when saveStructures declines a save (a concurrent writer updated the shared
+		// structures, or the store txn did not durably commit), the in-memory structures/transition
+		// trie reference a record id that was never persisted. The re-pack must reload the durable
+		// structures and re-mint/re-save — otherwise it re-emits the same record pointing at an
+		// unsaved structure, and reads throw "Record id is not defined".
+		const meta = new Packr();
+		let store = null;
+		let declinedOnce = false;
+		const packr = new Packr({
+			useRecords: true,
+			getStructures() { return store ? meta.unpack(store) : undefined; },
+			saveStructures(structures) {
+				if (!declinedOnce) { declinedOnce = true; return false; } // decline the first save
+				store = meta.pack(structures); return true;
+			},
+		});
+		const a = packr.pack({ x: 9, y: 8 });
+		const b = packr.pack({ x: 7, y: 6 });
+		const reader = new Packr({ getStructures() { return store ? meta.unpack(store) : undefined; } });
+		assert.deepEqual(reader.unpack(a), { x: 9, y: 8 });
+		assert.deepEqual(reader.unpack(b), { x: 7, y: 6 });
+	});
+
 	test('big buffer', function() {
 		var size = 100000000;
 		var data = new Uint8Array(size).fill(1);


### PR DESCRIPTION
## Summary

v2 port of #186. When `saveStructures` returns `false` (concurrent shared-structures update, or the host store transaction did not durably commit), mark structures **uninitialized** before re-packing so the re-pack reloads durable structures via `getStructures`, rebuilds the transition trie, and re-mints + re-saves — instead of re-emitting the same record referencing a structure id that was never persisted (→ `Record id is not defined for N` on a fresh reader).

See **[#186](https://github.com/kriszyp/msgpackr/pull/186)** (v1.11.x) for the full root-cause writeup and the paired host-side fix. One-line `pack.js` change + a regression test ("declined structure save re-packs against durable structures").

🤖 Generated by Claude (Opus 4.7).