### PR TITLE
Add readOnlyStructures option (write-disable, read-compatible) — 1.12.0

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -123,7 +123,13 @@ export class Packr extends Unpackr {
 				hasSharedUpdate = false
 			let encodingError;
 			try {
-				if (packr.randomAccessStructure && value && typeof value === 'object') {
+				// readOnlyStructures: skip the random-access struct write path so NO new struct is
+				// minted. randomAccessStructure stays true (the struct READ path and the struct-safe
+				// integer boundary are preserved, so existing struct data still decodes), but objects
+				// fall through to the normal pack()->writeObject->writeRecord path and are written as
+				// classic shared-structure records (byte range 0x40-0x7f, disjoint from struct headers
+				// at 0x20-0x3f) — the bounded, width-agnostic encoding used before struct mode.
+				if (packr.randomAccessStructure && !packr.readOnlyStructures && value && typeof value === 'object') {
 					if (value.constructor === Object) writeStruct(value); // simple object
 					else if (value.constructor !== Map && !Array.isArray(value) && !extensionClasses.some(extClass => value instanceof extClass)) {
 						// allow user classes, if they don't need special handling (but do use toJSON if available)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "msgpackr",
   "author": "Kris Zyp",
-  "version": "1.11.14",
+  "version": "1.12.0",
   "description": "Ultra-fast MessagePack implementation with extensions for records and structured cloning",
   "license": "MIT",
   "types": "./index.d.ts",

--- a/tests/test.js
+++ b/tests/test.js
@@ -1626,3 +1626,72 @@ suite('msgpackr – maxOwnStructures cap (randomAccessStructure)', function () {
 		assert.ok(packr.typedStructs.length <= 1, 'retry-path records must not exceed the cap, got ' + packr.typedStructs.length);
 	});
 })
+
+suite('msgpackr – readOnlyStructures (write-disable, read-compatible)', function () {
+	// readOnlyStructures keeps randomAccessStructure decode semantics — existing random-access
+	// struct data still decodes and the struct-safe integer boundary is preserved — but never mints
+	// a new random-access structure on write. Objects fall through to the classic shared-structure
+	// record path (bytes 0x40-0x7f, disjoint from struct headers at 0x20-0x3f), the bounded,
+	// width-agnostic encoding used before struct mode. This is the mechanism for disabling typed
+	// structures on an existing store without breaking reads.
+	const sharedStore = () => {
+		let saved;
+		return { getStructures: () => saved, saveStructures: (s) => { saved = s; return true; } };
+	};
+
+	test('decodes pre-existing random-access structs (read stays enabled)', function () {
+		const full = new Packr({ randomAccessStructure: true, useRecords: true });
+		const rec = { a: 1, b: 'hello', c: true, n: 42 };
+		const buf = full.pack(rec);
+		assert.ok(buf[0] >= 0x20 && buf[0] < 0x40, 'control: full encoder emits a random-access struct');
+
+		const ro = new Packr({ randomAccessStructure: true, useRecords: true, readOnlyStructures: true });
+		ro.typedStructs = full.typedStructs; // share the existing random-access dictionary
+		assert.deepEqual(ro.unpack(buf), rec);
+	});
+
+	test('writes classic shared-structure records (0x40-0x7f), never a random-access struct', function () {
+		const ro = new Packr({ randomAccessStructure: true, useRecords: true, readOnlyStructures: true, ...sharedStore() });
+		const rec = { x: 9, y: 'world', z: [1, 2, 3], nested: { deep: 50, k: 42 } };
+		const b1 = ro.pack(rec);
+		assert.ok(b1[0] >= 0x40 && b1[0] < 0x80, 'expected a classic record (0x40-0x7f), got 0x' + b1[0].toString(16));
+		assert.strictEqual(ro.typedStructs ? ro.typedStructs.length : 0, 0, 'no random-access struct minted');
+		assert.deepEqual(ro.unpack(b1), rec);
+		// a second record of the same shape reuses the shared classic structure (still classic)
+		const b2 = ro.pack({ x: 1, y: 'a', z: [], nested: { deep: 0, k: 0 } });
+		assert.ok(b2[0] >= 0x40 && b2[0] < 0x80, 'second record also classic');
+	});
+
+	test('preserves the struct-safe integer boundary (nested 0x20-0x3f ints do not collide)', function () {
+		const ro = new Packr({ randomAccessStructure: true, useRecords: true, readOnlyStructures: true, ...sharedStore() });
+		for (const v of [0x1f, 0x20, 0x2a, 0x3f, 0x40, 0x7f]) {
+			assert.deepEqual(ro.unpack(ro.pack({ v, nested: { w: v } })), { v, nested: { w: v } });
+		}
+	});
+
+	test('a normal randomAccessStructure reader decodes readOnly classic records (replication compat)', function () {
+		let saved;
+		const store = { getStructures: () => saved, saveStructures: (s) => { saved = s; return true; } };
+		const ro = new Packr({ randomAccessStructure: true, useRecords: true, readOnlyStructures: true, ...store });
+		const roBuf = ro.pack({ p: 'q', n: 42 });
+		assert.ok(roBuf[0] >= 0x40 && roBuf[0] < 0x80, 'readOnly writes a classic record');
+
+		// A peer that is NOT readOnly (a normal struct-writing node) shares the classic-structure
+		// store and decodes the classic record correctly — no mapsAsObjects needed, since classic
+		// records decode to objects natively.
+		const peer = new Packr({ randomAccessStructure: true, useRecords: true, ...store });
+		assert.deepEqual(peer.unpack(roBuf), { p: 'q', n: 42 });
+	});
+
+	test('every object shape uses the classic path (null-proto, shadowed ctor) — no random-access struct', function () {
+		const ro = new Packr({ randomAccessStructure: true, useRecords: true, readOnlyStructures: true, ...sharedStore() });
+
+		const np = Object.create(null); np.a = 1; np.b = 'x';
+		assert.deepEqual(ro.unpack(ro.pack(np)), { a: 1, b: 'x' });
+
+		const cs = { constructor: 'shadow', a: 1 };
+		assert.deepEqual(ro.unpack(ro.pack(cs)), { constructor: 'shadow', a: 1 });
+
+		assert.strictEqual(ro.typedStructs ? ro.typedStructs.length : 0, 0, 'no random-access struct minted for any shape');
+	});
+})


### PR DESCRIPTION
## Summary

Adds a `readOnlyStructures` encoder option to the v1 line (minor bump → **1.12.0**, new public option). When set, the encoder:
- **keeps `randomAccessStructure` decode semantics** — existing random-access struct data still decodes, and the struct-safe integer boundary is preserved (nested ints in `0x20–0x3f` are written as uint8, not bare fixints);
- **skips the struct write path** — never mints a new random-access structure;
- **falls through to the classic shared-structure record path** (bytes `0x40–0x7f`, disjoint from struct headers at `0x20–0x3f`) — the bounded, width-agnostic encoding used before struct mode.

## Why

Downstream (Harper v5.0) needs to disable typed-structure *writes* on a store that **already holds** random-access struct records, without breaking reads of that data. In the v1 line, `randomAccessStructure` is a single flag gating reads, writes, and the integer boundary — flipping it off breaks reads, and there's no separate write hook (that's v2-only). This adds a clean write-disable that preserves reads.

This matches Harper 5.1's behavior exactly: when typed structures are disabled there, records fall back to msgpackr's classic shared structures (`0x40`). v5.0 (this option) does the same.

## What to look at

`pack.js`: a single guard — the random-access struct fast-path is skipped under `readOnlyStructures`, so objects flow through the normal `pack → writeObject → writeRecord` (classic) path for **every** object shape (plain, null-prototype, constructor-shadowed, class-instance fall-throughs). The integer boundary code is untouched (still keyed on `randomAccessStructure`), so it stays struct-safe. No `unpack.js` change is needed — classic records decode to objects natively.

## Tests

`tests/test.js` → `readOnlyStructures` suite (5 tests): read-compat (decodes pre-existing structs), classic-record output (`0x40–0x7f`) with no random-access struct minted, struct-safe integer boundary, **cross-read by a normal `randomAccessStructure` reader** sharing the classic-structure store (the replication case — works with **no `mapsAsObjects`** needed), and all object shapes using the classic path. Full suite: **107 passing, 0 failing**.

## Review

Codex cross-model review of the earlier (plain-map) iteration flagged a P2 on non-`Object`-constructor shapes; the reworked classic-fallback approach handles all shapes through the normal record path and is covered by the suite.

## Publish note

v1 maintenance line → publish under **`--tag previous`** (keeps `latest` = 2.0.3).

🤖 Generated by Claude (Opus 4.7).