### PR TITLE
Fix undecodable over-cap record definitions in two-byte mode (v1.12.x)

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -1695,3 +1695,95 @@ suite('msgpackr – readOnlyStructures (write-disable, read-compatible)', functi
 		assert.strictEqual(ro.typedStructs ? ro.typedStructs.length : 0, 0, 'no random-access struct minted for any shape');
 	});
 })
+
+suite('msgpackr – two-byte record definitions (over-cap own records with a shared store)', function () {
+	// Regression for a data-corruption bug: with a shared-structures store (getStructures/
+	// saveStructures) and maxOwnStructures > 32, msgpackr uses two-byte record ids
+	// (useTwoByteRecords). Over-cap "own" record shapes fall back to the classic record encoder,
+	// which emits a SELF-CONTAINED record definition (0xd5 0x72 <firstByte> <highByte> <keys>
+	// <values>). On read, recordDefinition() consumed the high byte itself, then invoked
+	// structure.read() — which, for a highByte === 0 structure, was a second-byte reader that
+	// consumed the FIRST VALUE BYTE as a phantom high byte, mis-resolving to a never-defined id
+	// ("Record id is not defined for N"). The one-byte path (maxOwnStructures <= 32, fixext 1
+	// 0xd4 0x72) was unaffected because no high byte / second-byte reader is involved.
+	// Fix: recordDefinition reads the body via the un-wrapped reader (structure.read0).
+	const sharedStore = () => {
+		let saved = [];
+		return { getStructures: () => saved, saveStructures: (s) => { saved = s; return true; }, peek: () => saved };
+	};
+	// Width-heterogeneous record generator: many distinct shapes, exceeding any modest cap, so
+	// the over-cap classic-record fallback path is exercised heavily.
+	const makeRecords = (count) => {
+		const out = [];
+		for (let i = 0; i < count; i++) {
+			const rec = { id: i };
+			const n = 1 + (i % 6);
+			for (let a = 0; a < n; a++) rec['attr_' + ((i * 7 + a) % 400)] = i % 2 ? 's' + i : i;
+			out.push(rec);
+		}
+		return out;
+	};
+
+	test('cap=256 + shared store round-trips every over-cap shape (two-byte mode)', function () {
+		const store = sharedStore();
+		const o = { randomAccessStructure: true, useRecords: true, useBigIntExtension: true, maxOwnStructures: 256, ...store };
+		const w = new Packr(o), r = new Packr(o);
+		const records = makeRecords(3000);
+		let sawTwoByteDef = false;
+		for (const rec of records) {
+			const buf = w.pack(rec);
+			if (buf[0] === 0xd5 && buf[1] === 0x72) sawTwoByteDef = true;
+			assert.deepEqual(r.unpack(buf), rec);
+		}
+		assert.ok(sawTwoByteDef, 'expected at least one two-byte (0xd5 0x72) record definition to be exercised');
+	});
+
+	test('readOnlyStructures + cap=256 + shared store round-trips (two-byte mode)', function () {
+		const store = sharedStore();
+		const o = { randomAccessStructure: true, useRecords: true, useBigIntExtension: true, readOnlyStructures: true, maxOwnStructures: 256, ...store };
+		const w = new Packr(o), r = new Packr(o);
+		for (const rec of makeRecords(3000)) {
+			assert.deepEqual(r.unpack(w.pack(rec)), rec);
+		}
+	});
+
+	test('over-cap own records do not grow the shared dictionary without bound', function () {
+		const store = sharedStore();
+		const o = { randomAccessStructure: true, useRecords: true, useBigIntExtension: true, maxOwnStructures: 256, ...store };
+		const w = new Packr(o);
+		for (const rec of makeRecords(3000)) w.pack(rec);
+		const saved = store.peek();
+		const named = saved instanceof Map ? (saved.get('named') || []) : (saved || []);
+		// The classic named-structures store must stay tiny (bounded by the few genuinely shared
+		// shapes); over-cap shapes are inlined as self-contained definitions, not minted as
+		// ever-growing shared ids.
+		assert.ok(named.length < 100, 'named structures should stay bounded, got ' + named.length);
+	});
+
+	test('two-byte record REFERENCES (shared, maxShared=64) round-trip with stable shapes', function () {
+		// maxSharedStructures > 32 forces two-byte mode; stable repeated shapes get a definition
+		// once then are emitted as two-byte references (0x60-0x7f + high byte) — the path that
+		// relies on structure.read remaining a second-byte reader after the fix.
+		const store = sharedStore();
+		const o = { useRecords: true, maxSharedStructures: 64, maxOwnStructures: 64, ...store };
+		const w = new Packr(o), r = new Packr(o);
+		const shapes = [];
+		for (let s = 0; s < 100; s++) { const rec = {}; for (let f = 0; f <= s % 8; f++) rec['k' + s + '_' + f] = s * 10 + f; shapes.push(rec); }
+		let sawRef = false;
+		for (let round = 0; round < 4; round++) for (const shp of shapes) {
+			const buf = w.pack(shp);
+			if (buf[0] >= 0x60 && buf[0] < 0x80) sawRef = true;
+			assert.deepEqual(r.unpack(buf), shp);
+		}
+		assert.ok(sawRef, 'expected at least one two-byte record reference (0x60-0x7f) to be exercised');
+	});
+
+	test('one-byte path (maxOwn=32) keeps working with a shared store', function () {
+		const store = sharedStore();
+		const o = { randomAccessStructure: true, useRecords: true, useBigIntExtension: true, maxOwnStructures: 32, ...store };
+		const w = new Packr(o), r = new Packr(o);
+		for (const rec of makeRecords(3000)) {
+			assert.deepEqual(r.unpack(w.pack(rec)), rec);
+		}
+	});
+})

--- a/unpack.js
+++ b/unpack.js
@@ -510,6 +510,7 @@ function createStructureReader(structure, firstId) {
 				inlineObjectReadThreshold = Infinity // disable going forward
 				return readObject(); // recursively try again
 			}
+			structure.read0 = optimizedReadObject // keep the un-wrapped body reader in sync
 			if (structure.highByte === 0)
 				structure.read = createSecondByteReader(firstId, structure.read)
 			return optimizedReadObject() // second byte is already read, if there is one so immediately read object
@@ -526,6 +527,12 @@ function createStructureReader(structure, firstId) {
 		return object
 	}
 	readObject.count = 0
+	// read0 is the un-wrapped body reader: it reads the record's values directly without
+	// consuming a leading high byte. recordDefinition uses it for the immediate read that follows
+	// a record definition (the high byte, if present, was already consumed). For highByte === 0
+	// structures the public reader is a second-byte reader (used by later references), but the
+	// definition read itself must not consume that byte.
+	structure.read0 = readObject
 	if (structure.highByte === 0) {
 		return createSecondByteReader(firstId, readObject)
 	}
@@ -1013,7 +1020,12 @@ const recordDefinition = (id, highByte) => {
 	}
 	currentStructures[id] = structure
 	structure.read = createStructureReader(structure, firstByte)
-	return structure.read()
+	// The high byte (if any) was already consumed as the `highByte` argument above, so read the
+	// record body directly. Going through structure.read (a second-byte reader when highByte === 0)
+	// would misinterpret the first value byte as a high byte — corrupting two-byte own-record
+	// definitions (0xd5 0x72 ...). createStructureReader stashes the un-wrapped body reader on
+	// structure.read0 precisely for this immediate post-definition read.
+	return (structure.read0 || structure.read)()
 }
 currentExtensions[0] = () => {} // notepack defines extension 0 to mean undefined, so use that as the default here
 currentExtensions[0].noBuffer = true


### PR DESCRIPTION
## Summary
With a shared-structures store and `maxOwnStructures > 32` (which selects msgpackr's two-byte record-id encoding), record shapes beyond the shared cap are written as self-contained record definitions (`0xd5 0x72 …`). On read, `recordDefinition()` already consumed the high byte (it's the `highByte` argument), then called `structure.read()` for the values — but `createStructureReader` returns a **second-byte reader** when `structure.highByte === 0` (the reader meant for later `0x60–0x7f` references). That reader consumed the **first value byte as a phantom high byte**, computing a bogus, never-defined record id (e.g. `96 + (203 << 5) = 6592`) → **`Record id is not defined for N`**. The records were undecodable even though the encoded bytes were correct. The one-byte path (`0xd4 0x72`, fixext 1, no high byte) was unaffected.

## Fix (read-path only, ~14 lines)
- `createStructureReader` stashes the un-wrapped body reader on `structure.read0`.
- `recordDefinition` uses `structure.read0` for the immediate post-definition read, so values are read directly without a phantom high byte. `structure.read` stays the second-byte reader for later references.

**The encoder is untouched**, so this is purely a read-side fix — already-written data (e.g. produced by 1.12.0) decodes correctly with it.

## Verification
- Repro (shared store, 3000 high-cardinality shapes): `maxOwnStructures=256` went from **~2900/3000 undecodable → 0**; with `readOnlyStructures` likewise 0; dictionary stays bounded (~33), not thousands.
- Full suite: **132 passing, 2 pending** (native acceleration on and off).
- Added a regression suite ("two-byte record definitions (over-cap own records with a shared store)") covering definitions, references, dictionary-boundedness, `readOnlyStructures`, and the one-byte path. The core cases fail on baseline with the exact original symptom and pass with the fix.

## Notes
- No version bump / publish here — leaving that to the maintainer (a 1.12.1 patch).
- `master` (v2) has the identical `recordDefinition`/`createStructureReader` defect; a matching port PR follows.
- Found via Harper 5.0.29, where high-cardinality tables hit this in production (undecodable records). Existing `#186` / cap / `readOnlyStructures` tests are untouched.

🤖 Authored with Claude (Opus 4.7).