### PR TITLE
docs: fix README parameter spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ You can also create an extension with `Class` and `write` methods, but no `type`
 Msgpackr is already fast, but here are some tips for making it faster:
 
 #### Buffer Reuse
-Msgpackr is designed to work well with reusable buffers. Allocating new buffers can be relatively expensive, so if you have Node addons, it can be much faster to reuse buffers and use memcpy to copy data into existing buffers. Then msgpackr `unpack` can be executed on the same buffer, with new data, and optionally take a second paramter indicating the effective size of the available data in the buffer.
+Msgpackr is designed to work well with reusable buffers. Allocating new buffers can be relatively expensive, so if you have Node addons, it can be much faster to reuse buffers and use memcpy to copy data into existing buffers. Then msgpackr `unpack` can be executed on the same buffer, with new data, and optionally take a second parameter indicating the effective size of the available data in the buffer.
 
 #### Arena Allocation (`useBuffer()`)
 During the serialization process, data is written to buffers. Again, allocating new buffers is a relatively expensive process, and the `useBuffer` method can help allow reuse of buffers that will further improve performance. With `useBuffer` method, you can provide a buffer, serialize data into it, and when it is known that you are done using that buffer, you can call `useBuffer` again to reuse it. The use of `useBuffer` is never required, buffers will still be handled and cleaned up through GC if not used, it just provides a small performance boost.


### PR DESCRIPTION
## Summary
- fix a README spelling typo: `paramter` -> `parameter`

## Validation
- `/usr/bin/grep -nE 'paramter|parameter|reusable buffers|effective size' README.md`\n- `git diff --check`\n\nNo package tests were run because this only changes README prose and does not alter code, command examples, generated output, or dependencies.