### PR TITLE
fix: round-trip `__proto__` keys as own properties (#159)

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -96,6 +96,28 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(deserialized, data);
 	});
 
+	test('__proto__ key (#159)', function () {
+		// A `__proto__` key must round-trip as an own property — not invoke the
+		// prototype setter, pollute the prototype, or be silently renamed.
+		let packr = new Packr();
+		// exercise the record path and, after several reads, the optimized reader
+		let many = [];
+		for (let i = 0; i < 80; i++) many.push(JSON.parse('{"__proto__": ' + i + ', "a": 1}'));
+		packr.unpack(packr.pack(many)).forEach(function (object, i) {
+			assert.equal(Object.getOwnPropertyDescriptor(object, '__proto__').value, i);
+			assert.equal(Object.getPrototypeOf(object), Object.prototype);
+			assert.equal(object.a, 1);
+		});
+		// maps-as-objects path
+		let mapPackr = new Packr({ mapsAsObjects: true, useRecords: false });
+		let asObject = mapPackr.unpack(mapPackr.pack(JSON.parse('{"__proto__": 7, "b": 2}')));
+		assert.equal(Object.getOwnPropertyDescriptor(asObject, '__proto__').value, 7);
+		assert.equal(asObject.b, 2);
+		// no prototype pollution even when the value is an object
+		packr.unpack(packr.pack(JSON.parse('{"__proto__": {"polluted": true}}')));
+		assert.isUndefined(({}).polluted);
+	});
+
 	test('mixed structures', function () {
 		let data1 = {a: 1, b: 2, c: 3};
 		let data2 = {a: 1, b: 2, d: 4};

--- a/unpack.js
+++ b/unpack.js
@@ -259,10 +259,7 @@ export function read() {
 			if (currentUnpackr.mapsAsObjects) {
 				let object = {};
 				for (let i = 0; i < token; i++) {
-					let key = readKey();
-					if (key === '__proto__')
-						key = '__proto_';
-					object[key] = read();
+					setObjectKey(object, readKey(), read());
 				}
 				return object;
 			} else {
@@ -495,6 +492,16 @@ export function read() {
 		}
 	}
 }
+function setObjectKey(object, key, value) {
+	if (key === '__proto__')
+		// define it as a real own property instead of invoking the prototype
+		// setter (which would also drop the data by renaming the key)
+		Object.defineProperty(object, '__proto__', {
+			value, configurable: true, enumerable: true, writable: true,
+		});
+	else
+		object[key] = value;
+}
 const validName = /^[a-zA-Z_$][a-zA-Z\d_$]*$/;
 function createStructureReader(structure, firstId) {
 	function readObject() {
@@ -503,7 +510,7 @@ function createStructureReader(structure, firstId) {
 			let optimizedReadObject;
 			try {
 				optimizedReadObject = structure.read = (new Function('r', 'return function(){return ' + (currentUnpackr.freezeData ? 'Object.freeze' : '') +
-					'({' + structure.map(key => key === '__proto__' ? '__proto_:r()' : validName.test(key) ? key + ':r()' : ('[' + JSON.stringify(key) + ']:r()')).join(',') + '})}'))(read);
+					'({' + structure.map(key => key === '__proto__' ? '["__proto__"]:r()' : validName.test(key) ? key + ':r()' : ('[' + JSON.stringify(key) + ']:r()')).join(',') + '})}'))(read);
 			} catch(error) {
 				// in CF workers, the new Function call could begin to fail at any point in time
 				inlineObjectReadThreshold = Infinity; // disable going forward
@@ -516,10 +523,7 @@ function createStructureReader(structure, firstId) {
 		}
 		let object = {};
 		for (let i = 0, l = structure.length; i < l; i++) {
-			let key = structure[i];
-			if (key === '__proto__')
-				key = '__proto_';
-			object[key] = read();
+			setObjectKey(object, structure[i], read());
 		}
 		if (currentUnpackr.freezeData)
 			return Object.freeze(object);
@@ -705,10 +709,7 @@ function readMap(length) {
 	if (currentUnpackr.mapsAsObjects) {
 		let object = {};
 		for (let i = 0; i < length; i++) {
-			let key = readKey();
-			if (key === '__proto__')
-				key = '__proto_';
-			object[key] = read();
+			setObjectKey(object, readKey(), read());
 		}
 		return object;
 	} else {


### PR DESCRIPTION
Implements the `__proto__` part of #159.

## Problem

A `__proto__` object key does not survive a round-trip — it is silently renamed to `__proto_` and its value is misplaced:

```js
import { pack, unpack } from 'msgpackr';

const value = JSON.parse('{"__proto__": 1, "a": 2}');
Object.keys(unpack(pack(value))); // ["__proto_", "a"]  ← key corrupted
Object.getOwnPropertyDescriptor(unpack(pack(value)), '__proto__'); // undefined
```

`unpack` rewrites the key to `__proto_` (in four places) to avoid prototype pollution from `object['__proto__'] = …`. It avoids pollution, but at the cost of corrupting the data.

## Fix

Per the suggestion in #159, set the key with `Object.defineProperty`, which creates a genuine own `__proto__` property without invoking the prototype setter — the same result `JSON.parse` and `structuredClone` produce. A small `setObjectKey` helper handles the three manual readers (the two `mapsAsObjects` paths and the record structure reader); the optimized compiled reader emits a computed `["__proto__"]` key (which is an own property, not the setter), so the fast path is preserved rather than disabled.

## Verification

Round-tripping `__proto__` now preserves it as an own property across every reader — the record path, the optimized record path (after the read threshold), the `mapsAsObjects`/map readers, and the default top-level `unpack` — and the prototype is never mutated (`({}).polluted` stays `undefined` even when the value is an object). A test covering these paths is added to `tests/test.js`.

> Note: I couldn't run `mocha` locally (it fails to start under Node 24+ via its `yargs` dependency), so the new test is verified against the source through a standalone harness exercising each path; CI runs it on a supported Node.
