### PR TITLE
docs: drop dead deno.land/x registry link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ receivingStream.on('data', (data) => {
 The `PackrStream` and `UnpackrStream` instances  will have also the record structure extension enabled by default (see below).
 
 ## Deno and Bun Usage
-Msgpackr modules are standard ESM modules and can be loaded directly from the [deno.land registry for msgpackr](https://deno.land/x/msgpackr) for use in Deno or using the NPM module loader with `import { unpack } from 'npm:msgpackr'`. The standard pack/encode and unpack/decode functionality is available on Deno, like other platforms. msgpackr can be used like any other package on Bun.
+Msgpackr modules are standard ESM modules and can be loaded in Deno with the NPM module loader, using `import { unpack } from 'npm:msgpackr'`. The standard pack/encode and unpack/decode functionality is available on Deno, like other platforms. msgpackr can be used like any other package on Bun.
 
 ## Browser Usage
 Msgpackr works as standalone JavaScript as well, and runs on modern browsers. It includes a bundled script, at `dist/index.js` for ease of direct loading:


### PR DESCRIPTION
The "Deno and Bun Usage" section links to `https://deno.land/x/msgpackr`, which returns 404. msgpackr has no entry on deno.land/x (versioned URLs such as `@v1.11.2` 404 as well), and there is no JSR package either — a JSR search for "msgpackr" returns only Deno's own unrelated `@std/msgpack`.

The same sentence already documents the working approach, `import { unpack } from 'npm:msgpackr'`, which is the current recommended way to consume npm packages from Deno. This drops the dead link and keeps that guidance.

Happy to instead restore a deno.land/x publish if the registry entry is meant to exist — just let me know and I'll close this.