### PR TITLE
fix: point non-string map key error at mapsAsObjects: false

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -1282,6 +1282,19 @@ suite('msgpackr basic tests', function() {
 		assert.deepEqual(unpacked, { '1,2,3': 1, '1,2,foo,3.14': 2 });
 	});
 
+	test('non-string map key into object suggests mapsAsObjects: false (#127)', function() {
+		const msgpackr = new Packr({ mapsAsObjects: true });
+		const map = new Map();
+		map.set({ nested: 'key' }, 1);
+		const packed = msgpackr.pack(map);
+		assert.throws(() => msgpackr.unpack(packed), /mapsAsObjects: false/);
+		// and the suggested option does preserve the key
+		const asMaps = new Packr({ mapsAsObjects: false });
+		const unpacked = asMaps.unpack(packed);
+		assert.equal(unpacked instanceof Map, true);
+		assert.deepEqual(Array.from(unpacked.keys())[0], { nested: 'key' });
+	});
+
 	test('utf16 causing expansion', function() {
 		this.timeout(10000);
 		let data = {fixstr: 'ᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝ', str8:'ᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝᾐᾑᾒᾓᾔᾕᾖᾗᾘᾙᾚᾛᾜᾝ'};

--- a/unpack.js
+++ b/unpack.js
@@ -1005,7 +1005,7 @@ function asSafeString(property) {
 	if (currentUnpackr.allowArraysInMapKeys && Array.isArray(property) && property.flat().every(item => ['string', 'number', 'boolean', 'bigint'].includes(typeof item))) {
 		return property.flat().toString();
 	}
-	throw new Error(`Invalid property type for record: ${typeof property}`);
+	throw new Error(`Invalid property type for record: ${typeof property}. A MessagePack map with non-string keys can be decoded as a Map with mapsAsObjects: false`);
 }
 // the registration of the record definition extension (as "r")
 const recordDefinition = (id, highByte) => {


### PR DESCRIPTION
Implements the error message improvement requested in #127.

Unpacking a MessagePack map with non-string keys into a plain object throws `Invalid property type for record: object`, which names records, points at nothing actionable, and (as the issue shows) sends people to the changelog instead of to the option that solves it. Decoding with `mapsAsObjects: false` preserves the original key type, which is what the reporter needed and what kriszyp suggested in the thread.

The message is now:

```
Invalid property type for record: object. A MessagePack map with non-string keys can be decoded as a Map with mapsAsObjects: false
```

The original first sentence is kept unchanged, since `asSafeString` also guards record structure definitions, where the record wording is accurate.

Test added covering both halves: the error matches `/mapsAsObjects: false/`, and the suggested option actually round-trips the object key. 92 passing; with `unpack.js` reverted the new test fails.
