### PR TITLE
Reject array and map lengths that exceed the remaining source data

### DIFF
--- a/tests/test-incomplete.js
+++ b/tests/test-incomplete.js
@@ -1,4 +1,4 @@
-import { encode } from '../index.js';
+import { encode, unpack, Unpackr } from '../index.js';
 import { assert } from 'chai';
 import { Encoder } from '../pack.js';
 
@@ -40,4 +40,46 @@ suite('encode and decode tests with partial values', function () {
       }
     });
   }
+});
+
+// An array or map header declares its element count up front. Decoding must not allocate for that
+// count before the elements are known to be present in the source, otherwise a few bytes of header
+// can force an arbitrarily large allocation.
+const malformedContainers = {
+  'array32 declaring 20 million elements': [0xdd, 0x01, 0x31, 0x2d, 0x00],
+  'array32 declaring 20 million elements with one present': [0xdd, 0x01, 0x31, 0x2d, 0x00, 0x01],
+  'array32 declaring the maximum length': [0xdd, 0xff, 0xff, 0xff, 0xff],
+  'array16 declaring 65535 elements': [0xdc, 0xff, 0xff],
+  'nested array32 declaring a million elements each': [0xdd, 0, 0x10, 0, 0, 0xdd, 0, 0x10, 0, 0],
+  'map32 declaring 20 million entries': [0xdf, 0x01, 0x31, 0x2d, 0x00],
+  'map16 declaring 65535 entries': [0xde, 0xff, 0xff],
+  'fixarray with no elements present': [0x9f]
+};
+
+suite('unpack malformed containers', function () {
+  this.timeout(1000); // these must all fail immediately, not after filling a declared length
+  const unpackrs = [
+    ['default', new Unpackr()],
+    ['mapsAsObjects: false', new Unpackr({ mapsAsObjects: false })],
+    ['useRecords', new Unpackr({ useRecords: true, structures: [] })]
+  ];
+  for (const [label, bytes] of Object.entries(malformedContainers)) {
+    test(label, () => {
+      for (const [unpackrLabel, unpackr] of unpackrs) {
+        try {
+          let value = unpackr.unpack(Buffer.from(bytes));
+          assert.fail(`${label} should not unpack (${unpackrLabel}), returned ${JSON.stringify(value)}`);
+        } catch (error) {
+          assert.isTrue(error.incomplete, `${label} (${unpackrLabel}): ${error.message}`);
+        }
+      }
+    });
+  }
+
+  test('rejecting an oversized declared length does not allocate', () => {
+    let before = process.memoryUsage().heapUsed;
+    assert.throws(() => unpack(Buffer.from([0xdd, 0x01, 0x31, 0x2d, 0x00])));
+    // before this was checked, the 5 byte header above allocated a 20 million element array (~150MB)
+    assert.isBelow((process.memoryUsage().heapUsed - before) / 1048576, 50, 'heap growth in MB');
+  });
 });

--- a/unpack.js
+++ b/unpack.js
@@ -485,11 +485,7 @@ export function read() {
 			default: // negative int
 				if (token >= 0xe0)
 					return token - 0x100;
-				if (token === undefined) {
-					let error = new Error('Unexpected end of MessagePack data');
-					error.incomplete = true;
-					throw error;
-				}
+				if (token === undefined) throw endOfMessagePackError();
 				throw new Error('Unknown MessagePack token ' + token);
 
 		}
@@ -697,7 +693,16 @@ export function readString(source, start, length) {
 	}
 }
 
+function endOfMessagePackError() {
+	let error = new Error('Unexpected end of MessagePack data');
+	error.incomplete = true;
+	return error;
+}
+
 function readArray(length) {
+	// every element occupies at least one byte, so a length beyond what remains in the source can never
+	// be satisfied; check before allocating so a small header can not force a large allocation
+	if (length > srcEnd - position) throw endOfMessagePackError();
 	let array = new Array(length);
 	for (let i = 0; i < length; i++) {
 		array[i] = read();
@@ -708,6 +713,7 @@ function readArray(length) {
 }
 
 function readMap(length) {
+	if (length > (srcEnd - position) / 2) throw endOfMessagePackError(); // each entry needs at least two bytes
 	if (currentUnpackr.mapsAsObjects) {
 		let object = {};
 		for (let i = 0; i < length; i++) {


### PR DESCRIPTION
Same class of resource-exhaustion issue as [kriszyp/cbor-x#141](https://github.com/kriszyp/cbor-x/pull/141), found while fixing that one — the two decoders share their lineage. Reported for cbor-x by Ezinne Kalu (https://github.com/zikk090); this repo was not part of that report, but has the same weakness in a narrower form.

## The issue

`readArray` allocates from the declared header length before a single element has been read:

```js
function readArray(length) {
	let array = new Array(length);   // length is attacker controlled and unsupported by any data
	for (let i = 0; i < length; i++) array[i] = read();
```

A 5-byte `array32` header declaring 20,000,000 elements therefore allocates a 20M-element array before `read()` reports the missing data. Measured on Node 24 / macOS arm64 against `master` (2.0.5):

| input | bytes | retained | time |
|---|---|---|---|
| `dd 01312d00` (array32, 20M) | 5 | **153 MB** | 14–28 ms |
| `dd 01312d00 01` (same, one element present) | 6 | 153 MB | 14 ms |
| `dd 00100000 dd 00100000` (nested, 1M each) | 10 | 16 MB | 1 ms |

~32,000,000x amplification from input size to retained memory. A single message is cheap in CPU terms, but concurrent decodes of tiny malformed messages can drive a process into memory pressure. Note the length has to land in V8's fast-elements range to be expensive: `array32` at its maximum (`dd ffffffff`) creates a dictionary-mode array and costs nothing, which is why the worst case is a mid-sized count rather than the largest one.

Maps are not affected in the same way (they grow lazily), and `str32`/`bin32` lengths are already clamped by `subarray`.

## The fix

Unlike cbor-x, an out-of-range read here already throws — `token === undefined` is checked — so the loops terminate on the first missing byte and no wider guard is needed. The defect is purely that the allocation happens before that check can run.

`readArray` and `readMap` now verify the declared length against the bytes that remain in the source before allocating or looping: every element occupies at least one byte, every map entry at least two, so a length beyond the remainder can never be satisfied. The error carries `incomplete = true`, as the overrun error already did, so streaming consumers keep buffering rather than failing.

The `readMap` check is defensive rather than a fix for observed memory growth; it costs nothing and keeps the two containers consistent.

## Verification

- 120 tests pass (9 new, in `tests/test-incomplete.js`). Being honest about what they cover: 8 of them already pass on `master` — msgpackr threw the right error before, it just allocated first — so the meaningful regression guard is `rejecting an oversized declared length does not allocate`, which fails on `master` with a 153 MB heap delta.
- All the malformed inputs above now fail in under a millisecond with no allocation.
- **Throughput unchanged.** The check only runs on `array16`/`array32`/`map16`/`map32` headers. Interleaved A/B (best-of-10, alternating patched/baseline): 100k-int array 427.9k/395.1k ns patched vs 412.8k/393.0k baseline; 10k-object array 875.8k/883.3k vs 889.8k/862.3k; small payload 2012/2044 vs 2006/2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)