### PR TITLE
Bound total array allocation to prevent a nested-array memory DoS

### DIFF
--- a/tests/test-incomplete.js
+++ b/tests/test-incomplete.js
@@ -82,4 +82,22 @@ suite('unpack malformed containers', function () {
     // before this was checked, the 5 byte header above allocated a 20 million element array (~150MB)
     assert.isBelow((process.memoryUsage().heapUsed - before) / 1048576, 50, 'heap growth in MB');
   });
+
+  test('nested array lengths that each fit the source but sum past it do not allocate', () => {
+    // each array16 header declares 65535 elements, which fits the remaining bytes on its own, so the
+    // per-array check passes at every level; without a shared budget the levels pre-allocate ~65535 *
+    // depth slots (~315MB here) before the missing elements are ever read
+    let depth = 600, length = 0xffff;
+    let bytes = Buffer.alloc(length + depth * 3 + 16);
+    for (let i = 0; i < depth; i++)
+      bytes.set([0xdc, 0xff, 0xff], i * 3);
+    let before = process.memoryUsage().heapUsed;
+    try {
+      unpack(bytes);
+      assert.fail('nested oversized arrays should not unpack');
+    } catch (error) {
+      assert.isTrue(error.incomplete, error.message);
+    }
+    assert.isBelow((process.memoryUsage().heapUsed - before) / 1048576, 50, 'heap growth in MB');
+  });
 });

--- a/unpack.js
+++ b/unpack.js
@@ -18,6 +18,7 @@ var bundledStrings;
 var referenceMap;
 var currentExtensions = [];
 var dataView;
+var arrayAllocationBudget;
 var defaultOptions = {
 	useRecords: false,
 	mapsAsObjects: true
@@ -179,6 +180,7 @@ export function checkedRead(options) {
 				currentStructures.length = sharedLength;
 		}
 		let result;
+		arrayAllocationBudget = srcEnd - position;
 		if (currentUnpackr._readStruct && src[position] < 0x40 && src[position] >= 0x20) {
 			result = currentUnpackr._readStruct(src, position, srcEnd);
 			src = null; // dispose of this so that recursive unpack calls don't save state
@@ -701,8 +703,10 @@ function endOfMessagePackError() {
 
 function readArray(length) {
 	// every element occupies at least one byte, so a length beyond what remains in the source can never
-	// be satisfied; check before allocating so a small header can not force a large allocation
-	if (length > srcEnd - position) throw endOfMessagePackError();
+	// be satisfied; check before allocating so a small header can not force a large allocation. Nested
+	// arrays each pass that per-array check yet still pre-allocate, so also spend from a per-decode
+	// budget of the remaining bytes -- the summed lengths of any valid tree stay under it
+	if (length > srcEnd - position || (arrayAllocationBudget -= length) < 0) throw endOfMessagePackError();
 	let array = new Array(length);
 	for (let i = 0; i < length; i++) {
 		array[i] = read();
@@ -1196,6 +1200,7 @@ function saveState(callback) {
 	let savedStrings = strings;
 	let savedReferenceMap = referenceMap;
 	let savedBundledStrings = bundledStrings;
+	let savedArrayAllocationBudget = arrayAllocationBudget;
 
 	// TODO: We may need to revisit this if we do more external calls to user code (since it could be slow)
 	let savedSrc = new Uint8Array(src.slice(0, srcEnd)); // we copy the data in case it changes while external data is processed
@@ -1213,6 +1218,7 @@ function saveState(callback) {
 	strings = savedStrings;
 	referenceMap = savedReferenceMap;
 	bundledStrings = savedBundledStrings;
+	arrayAllocationBudget = savedArrayAllocationBudget;
 	src = savedSrc;
 	sequentialMode = savedSequentialMode;
 	currentStructures = savedStructures;


### PR DESCRIPTION
#199 added a per-array check so a single array header cannot declare more elements than there are bytes left in the source (`length > srcEnd - position`). But `readArray` still allocates `new Array(length)` up front, and the check re-measures the remaining bytes **at each nesting level**. A chain of `array16` headers that each declare 65535 elements passes the per-array check at every level (65535 ≤ the still-large remainder) while each preallocates a 65535-slot array — so a few kilobytes of headers retain hundreds of MB across the chain.

```js
// nested array16 headers: 0xdc 0xff 0xff (declares 65535), repeated
const depth = 24000, buf = Buffer.alloc(depth * 3)
for (let i = 0; i < depth; i++) buf.set([0xdc, 0xff, 0xff], i * 3)
unpack(buf)
```

Measured on HEAD (post-#199): a ~73 KB input reaches ~1.4 GB RSS before throwing; under `node --max-old-space-size=512` (a typical container cap) a **~72 KB** payload aborts the process with `FATAL ERROR: JavaScript heap out of memory` — uncatchable, a caller `try/catch` around `unpack()` does not save it. Reproduces with default options (also `mapsAsObjects: false`, `useRecords`). The `nested array32` test added with #199 does not catch this: its 10-byte buffer is stopped by the per-array check, a large buffer is not.

**Attacker → control:** an unauthenticated party who can hand a MessagePack buffer to any service decoding untrusted input (msgpackr's core use case — RPC, queues, websockets, IPC); the defeated control is the #199 length check.

## Fix

Spend each array's length from a per-decode budget of the remaining bytes, set in `checkedRead` and saved/restored across the `saveState` boundary:

```js
if (length > srcEnd - position || (arrayAllocationBudget -= length) < 0) throw endOfMessagePackError()
```

The summed lengths of any valid tree are below the byte count (every element costs at least one byte), so valid data is never rejected, while the nested attack throws a catchable incomplete error at a bounded size (~0.5 MB).

## Tests

A case in `tests/test-incomplete.js` (next to the #199 test) asserts the nested payload is rejected with < 50 MB heap growth; it OOM-hangs on the current code and passes with the fix. Full suite: 121 passing.
